### PR TITLE
feat: support stacked units per hex, robust move/ram UI, and regression tests

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,4 @@
 {
+  "MD013": false,
   "MD036": false
 }

--- a/docs/web-ui-spec.md
+++ b/docs/web-ui-spec.md
@@ -197,6 +197,40 @@ unit roster, unit positions, or unit status once authoritative game data has loa
 2. The header should show the current player role from session context.
 3. At game end, show a dedicated result overlay with outcome and next actions.
 
+## Move Mechanics (UI Interaction Spec)
+
+**Eligibility:**
+
+- A unit is eligible to move if it is operational and has at least 1 movement allowance remaining in the current phase.
+
+**Unit Highlighting:**
+
+- During the player’s movement phase, all eligible units are visually highlighted. The highlight may be applied to the unit icon or the entire hex it occupies.
+- The currently selected unit’s hex is distinctly highlighted to indicate selection.
+
+**Selection & Deselection:**
+
+- Left-clicking on any unit selects it, displaying its details in the right rail and deselecting any previously selected unit.
+- Left-clicking on any empty hex or non-unit area of the hexmap deselects the current selection and removes all move overlays.
+
+**Move Radius & Action:**
+
+- When a unit with remaining movement allowance is selected, all hexes within its movement range are highlighted with a subtle green overlay, visually distinct from the selected hex.
+- Right-clicking on a highlighted (in-range) hex instantly moves the selected unit to that hex, submits the move event, and refreshes the UI with the unit deselected.
+- Selecting a unit with no move eligibility displays its stats but does not highlight any move radius.
+
+**Error Feedback:**
+
+- Right-clicking on an ineligible (out-of-range or blocked) hex displays a temporary “out of range” bubble near the cursor.
+- The error bubble remains visible for 3 seconds or until dismissed by clicking anywhere.
+
+**Other Behaviors:**
+
+- Only one unit can be selected at a time.
+- All move overlays and highlights are cleared when no unit is selected.
+- Movement is instant; no confirmation dialog is required.
+- Game state is stable during the player’s movement phase; no external changes are expected.
+
 ## Error Handling UX Baseline
 
 1. Show user-friendly message + machine details.

--- a/docs/web-ui-spec.md
+++ b/docs/web-ui-spec.md
@@ -221,7 +221,7 @@ unit roster, unit positions, or unit status once authoritative game data has loa
 
 **Error Feedback:**
 
-- Right-clicking on an ineligible (out-of-range or blocked) hex displays a temporary “out of range” bubble near the cursor.
+- Right-clicking on an ineligible (out-of-range or blocked) hex displays a temporary “Illegal move” bubble near the cursor.
 - The error bubble remains visible for 3 seconds or until dismissed by clicking anywhere.
 
 **Other Behaviors:**

--- a/src/api/games.actions.move.test.ts
+++ b/src/api/games.actions.move.test.ts
@@ -6,18 +6,20 @@ import * as engineGame from '../engine/index.js'
 import { createGame, createMovePlan, joinGame, register } from './helpers.js'
 import logger from '../logger.js'
 
-let infoSpy: any, warnSpy: any, errorSpy: any;
+let infoSpy: any, warnSpy: any, errorSpy: any, debugSpy: any;
 
 beforeEach(() => {
   infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
   warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
   errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 });
 
 afterEach(() => {
   infoSpy.mockRestore();
   warnSpy.mockRestore();
   errorSpy.mockRestore();
+  debugSpy.mockRestore();
 });
 
 describe('POST /games/:id/actions MOVE', () => {
@@ -49,6 +51,15 @@ describe('POST /games/:id/actions MOVE', () => {
     expect(body.state.onion.position).toEqual(moveTo)
     expect(validateSpy).toHaveBeenCalled()
     expect(executeSpy).toHaveBeenCalled()
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gameId,
+        actionType: 'MOVE',
+        eventCount: 1,
+        eventTypes: ['ONION_MOVED'],
+      }),
+      'Events sent',
+    )
     validateSpy.mockRestore()
     executeSpy.mockRestore()
 
@@ -56,6 +67,42 @@ describe('POST /games/:id/actions MOVE', () => {
     expect(infoSpy).toHaveBeenCalled()
     // Optionally: expect(warnSpy).not.toHaveBeenCalled()
     // Optionally: expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('records spent movement in the returned state after a successful move', async () => {
+    const app = buildApp()
+    const shrek = await register(app, 'shrek')
+    const fiona = await register(app, 'fiona')
+    const { gameId } = await createGame(app, shrek.token, 'onion')
+    await joinGame(app, gameId, fiona.token)
+
+    const initialStateRes = await app.inject({
+      method: 'GET',
+      url: `/games/${gameId}`,
+      headers: { authorization: `Bearer ${shrek.token}` },
+    })
+    const initialStateBody = initialStateRes.json<{ state: { onion: { id?: string; position: { q: number; r: number } } } }>()
+    const onionUnitId = initialStateBody.state.onion.id ?? 'onion'
+
+    const moveTo = { q: 1, r: 10 }
+    const validatedPlan = createMovePlan({ unitId: onionUnitId, from: initialStateBody.state.onion.position, to: moveTo, path: [moveTo], cost: 1 })
+    const validateSpy = vi.spyOn(engineGame, 'validateUnitMovement').mockReturnValue({ ok: true, plan: validatedPlan } as any)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/games/${gameId}/actions`,
+      headers: { authorization: `Bearer ${shrek.token}` },
+      payload: { type: 'MOVE', unitId: onionUnitId, to: moveTo },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.ok).toBe(true)
+    expect(body.state.onion.position).toEqual(moveTo)
+    expect(body.state.movementSpent).toMatchObject({ [`ONION_MOVE:${onionUnitId}`]: 1 })
+    expect(body.movementRemainingByUnit).toMatchObject({ [onionUnitId]: 2 })
+    expect(validateSpy).toHaveBeenCalled()
+    validateSpy.mockRestore()
   })
 
   it('returns 422 when execution fails', async () => {

--- a/src/api/games.actions.move.test.ts
+++ b/src/api/games.actions.move.test.ts
@@ -82,7 +82,7 @@ describe('POST /games/:id/actions MOVE', () => {
       headers: { authorization: `Bearer ${shrek.token}` },
     })
     const initialStateBody = initialStateRes.json<{ state: { onion: { id?: string; position: { q: number; r: number } } } }>()
-    const onionUnitId = initialStateBody.state.onion.id ?? 'onion'
+    const onionUnitId = initialStateBody.state.onion.id ?? 'onion-1'
 
     const moveTo = { q: 1, r: 10 }
     const validatedPlan = createMovePlan({ unitId: onionUnitId, from: initialStateBody.state.onion.position, to: moveTo, path: [moveTo], cost: 1 })

--- a/src/api/games.state.test.ts
+++ b/src/api/games.state.test.ts
@@ -23,10 +23,12 @@ describe('GET /games/:id', () => {
     expect(body.turnNumber).toBe(1)
     expect(body.winner).toBeNull()
     expect(body).toHaveProperty('state')
+    expect(body).toHaveProperty('movementRemainingByUnit')
     expect(body).toHaveProperty('scenarioMap')
     expect(body.scenarioMap.width).toBeGreaterThan(0)
     expect(body.scenarioMap.height).toBeGreaterThan(0)
     expect(typeof body.eventSeq).toBe('number')
+    expect(body.movementRemainingByUnit[body.state.onion.id ?? 'onion-1']).toBe(3)
   })
 
   it('returns 401 without auth', async () => {

--- a/src/api/games.ts
+++ b/src/api/games.ts
@@ -12,6 +12,7 @@ import { advancePhaseWithEvents } from '../engine/game.js'
 import { createMap } from '../engine/map.js'
 import { validateUnitMovement, executeUnitMovement, validateCombatAction, executeCombatAction } from '../engine/index.js'
 import type { EngineGameState } from '../engine/units.js'
+import { getRemainingUnitMovementAllowance } from '../shared/unitMovement.js'
 import { InitialStateSchema } from '../engine/scenarioSchema.js'
 import { normalizeInitialStateToGameState } from '../engine/scenarioNormalizer.js'
 import { resolveScenariosDir } from './scenarioPaths.js'
@@ -68,6 +69,26 @@ function buildEngineState(match: MatchRecord) {
     currentPhase: match.phase,
     turn: match.turnNumber,
   } as EngineGameState
+}
+
+function buildMovementRemainingByUnit(state: GameState, phase: TurnPhase): Record<string, number> {
+  const movementRemainingByUnit: Record<string, number> = {}
+  const onionId = state.onion.id ?? 'onion-1'
+
+  movementRemainingByUnit[onionId] = getRemainingUnitMovementAllowance(
+    state.onion.type ?? 'TheOnion',
+    phase,
+    state,
+    onionId,
+    state.onion.treads,
+  )
+
+  for (const [defenderId, defender] of Object.entries(state.defenders)) {
+    const resolvedId = defender.id ?? defenderId
+    movementRemainingByUnit[resolvedId] = getRemainingUnitMovementAllowance(defender.type, phase, state, resolvedId)
+  }
+
+  return movementRemainingByUnit
 }
 
 function getScenarioMaxTurns(scenarioSnapshot: ScenarioSnapshot | undefined): number {
@@ -207,6 +228,19 @@ function buildCombatEvents(
   }
 
   return events
+}
+
+function logSentEvents(gameId: number, actionType: string, events: EventEnvelope[]) {
+  logger.debug(
+    {
+      gameId,
+      actionType,
+      eventCount: events.length,
+      eventTypes: events.map((event) => event.type),
+      events,
+    },
+    'Events sent',
+  )
 }
 
 /**
@@ -490,6 +524,7 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
         winner: match.winner,
         players: match.players,
         state: match.state,
+        movementRemainingByUnit: buildMovementRemainingByUnit(match.state, match.phase),
         scenarioMap,
         eventSeq: match.events.at(-1)?.seq ?? 0,
       })
@@ -594,8 +629,9 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
         // Return updated state and events
         const turnNumber = result.turnNumber
         const eventSeq = newEvents.at(-1)?.seq ?? 0
+        logSentEvents(match.gameId, 'END_PHASE', newEvents)
         logger.debug({ gameId: match.gameId, phase: match.phase, turnNumber }, 'Phase advanced')
-        return reply.send({ ok: true, seq: eventSeq, events: newEvents, state: currentState, turnNumber, eventSeq })
+        return reply.send({ ok: true, seq: eventSeq, events: newEvents, state: currentState, movementRemainingByUnit: buildMovementRemainingByUnit(currentState, result.phase), turnNumber, eventSeq })
       } else if (command.type === 'MOVE') {
         logger.info({ gameId: match.gameId, unitId: command.unitId }, 'Processing MOVE command')
         const scenarioSnapshot = match.scenarioSnapshot as ScenarioSnapshot
@@ -662,8 +698,9 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
         })
         const turnNumber = match.turnNumber
         const eventSeq = newEvents.at(-1)?.seq ?? nextSeq - 1
+        logSentEvents(match.gameId, 'MOVE', newEvents)
         logger.debug({ gameId: match.gameId, unitId: command.unitId }, 'Move executed')
-        return reply.send({ ok: true, seq: newEvents[0].seq, events: newEvents, state: currentState, turnNumber, eventSeq })
+        return reply.send({ ok: true, seq: newEvents[0].seq, events: newEvents, state: currentState, movementRemainingByUnit: buildMovementRemainingByUnit(currentState, match.phase), turnNumber, eventSeq })
       } else if (command.type === 'FIRE' || command.type === 'FIRE_WEAPON' || command.type === 'FIRE_UNIT' || command.type === 'COMBINED_FIRE') {
         logger.info({ gameId: match.gameId, type: command.type }, 'Processing combat command')
         const scenarioSnapshot = match.scenarioSnapshot as ScenarioSnapshot
@@ -707,8 +744,9 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
         })
         const turnNumber = match.turnNumber
         const eventSeq = newEvents.at(-1)?.seq ?? seq
+        logSentEvents(match.gameId, command.type, newEvents)
         logger.debug({ gameId: match.gameId, type: command.type }, 'Combat executed')
-        return reply.send({ ok: true, seq: eventSeq, events: newEvents, state: currentState, turnNumber, eventSeq })
+        return reply.send({ ok: true, seq: eventSeq, events: newEvents, state: currentState, movementRemainingByUnit: buildMovementRemainingByUnit(currentState, match.phase), turnNumber, eventSeq })
       }
     } catch (err) {
       if (err instanceof StaleMatchStateError) {

--- a/src/engine/game.ts
+++ b/src/engine/game.ts
@@ -1,3 +1,4 @@
+import { resetMovementSpent } from '../shared/unitMovement.js'
 import logger from '../logger.js';
 import type { TurnPhase, GameState, EventEnvelope } from '../types/index.js';
 import type { MatchRecord } from '../db/adapter.js';
@@ -63,6 +64,7 @@ export function advancePhaseWithEvents(match: Pick<MatchRecord, 'phase' | 'turnN
 
   if (phase === 'ONION_MOVE') {
     state.ramsThisTurn = 0;
+    resetMovementSpent(state);
     refreshOnionWeaponsForNewTurn(state);
     // Reset defender weapons for the new turn
     for (const unit of Object.values(state.defenders)) {

--- a/src/engine/movement.ts
+++ b/src/engine/movement.ts
@@ -9,9 +9,10 @@ import logger from '../logger.js'
 import type { HexPos, PlayerRole, Command } from '../types/index.js'
 import { isInBounds } from './map.js'
 import type { GameMap } from './map.js'
-import { getUnitDefinition, onionMovementAllowance, isImmobile } from './units.js'
+import { getUnitDefinition, isImmobile } from './units.js'
 import type { GameUnit, DefenderUnit, EngineGameState, OnionUnit } from './units.js'
 import { findMovePath, type MoveMapSnapshot } from '../shared/movePlanner.js'
+import { canUnitCrossRidgelines, canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, spendUnitMovement } from '../shared/unitMovement.js'
 
 /**
  * Result of validating a movement command.
@@ -106,13 +107,11 @@ function resolveUnit(state: EngineGameState, unitId: string): ResolvedUnit | nul
 }
 
 function getCapabilities(unit: GameUnit): MovementCapabilities {
-  const definition = getUnitDefinition(unit.type)
-
   return {
-    canRam: definition.abilities.canRam === true,
+    canRam: getUnitDefinition(unit.type).abilities.canRam === true,
     hasTreads: hasTreads(unit),
-    canSecondMove: definition.abilities.secondMove === true,
-    canCrossRidgelines: definition.abilities.canCrossRidgelines === true,
+    canSecondMove: canUnitSecondMove(unit.type),
+    canCrossRidgelines: canUnitCrossRidgelines(unit.type),
   }
 }
 
@@ -122,16 +121,18 @@ function getMovementAllowance(
   role: PlayerRole,
   capabilities: MovementCapabilities
 ): MovementAllowanceResult {
-  const definition = getUnitDefinition(unit.type)
-
   if (role === 'onion') {
     if (state.currentPhase !== 'ONION_MOVE') {
       return { ok: false, code: 'WRONG_PHASE', error: 'Not the Onion movement phase' }
     }
 
-    const movementAllowance = capabilities.hasTreads
-      ? onionMovementAllowance((unit as OnionUnit).treads)
-      : definition.movement
+    const movementAllowance = getRemainingUnitMovementAllowance(
+      unit.type,
+      state.currentPhase,
+      state,
+      unit.id,
+      capabilities.hasTreads ? (unit as OnionUnit).treads : undefined,
+    )
 
     if (movementAllowance === 0) {
       return { ok: false, code: 'NO_MOVEMENT_ALLOWANCE', error: 'Unit has no movement allowance' }
@@ -145,7 +146,7 @@ function getMovementAllowance(
       return { ok: false, code: 'SECOND_MOVE_NOT_ALLOWED', error: 'Unit cannot perform a second move' }
     }
 
-    const movementAllowance = definition.abilities.secondMoveAllowance ?? 0
+    const movementAllowance = getRemainingUnitMovementAllowance(unit.type, state.currentPhase, state, unit.id)
     if (movementAllowance === 0) {
       return { ok: false, code: 'NO_MOVEMENT_ALLOWANCE', error: 'Unit has no movement allowance' }
     }
@@ -157,9 +158,7 @@ function getMovementAllowance(
     return { ok: false, code: 'WRONG_PHASE', error: 'Not a defender movement phase' }
   }
 
-  const movementAllowance = capabilities.hasTreads
-    ? onionMovementAllowance((unit as OnionUnit).treads)
-    : definition.movement
+  const movementAllowance = getRemainingUnitMovementAllowance(unit.type, state.currentPhase, state, unit.id)
 
   if (movementAllowance === 0) {
     return { ok: false, code: 'NO_MOVEMENT_ALLOWANCE', error: 'Unit has no movement allowance' }
@@ -265,11 +264,13 @@ function validateMovePlan(
   }
 
   const pathResult = findMovePath({
-    map: toMoveMapSnapshot(map),
+    map: toMoveMapSnapshot(map, state, unit.id),
     from: unit.position,
     to: command.to,
     movementAllowance: allowance.movementAllowance,
     canCrossRidgelines: capabilities.canCrossRidgelines,
+    movingRole: role,
+    movingUnitType: unit.type,
   })
   if (!pathResult.found) {
     return {
@@ -316,7 +317,16 @@ function validateMovePlan(
   }
 }
 
-function toMoveMapSnapshot(map: GameMap): MoveMapSnapshot {
+function toMoveMapSnapshot(map: GameMap, state: EngineGameState, movingUnitId: string): MoveMapSnapshot {
+  const occupiedHexes: NonNullable<MoveMapSnapshot['occupiedHexes']> = [
+    ...(state.onion.id !== movingUnitId && state.onion.status !== 'destroyed'
+      ? [{ q: state.onion.position.q, r: state.onion.position.r, role: 'onion' as const, unitType: state.onion.type ?? 'TheOnion', squads: 1 }]
+      : []),
+    ...Object.values(state.defenders)
+      .filter((unit) => unit.id !== movingUnitId && unit.status !== 'destroyed')
+      .map((unit) => ({ q: unit.position.q, r: unit.position.r, role: 'defender' as const, unitType: unit.type, squads: unit.squads })),
+  ]
+
   return {
     width: map.width,
     height: map.height,
@@ -325,6 +335,7 @@ function toMoveMapSnapshot(map: GameMap): MoveMapSnapshot {
       r: hex.r,
       t: hex.terrain === 'ridgeline' ? 1 : hex.terrain === 'crater' ? 2 : 0,
     })),
+    occupiedHexes,
   }
 }
 
@@ -336,6 +347,7 @@ function executeMovePlan(state: EngineGameState, plan: MovementPlan): MovementRe
 
   const { unit } = resolved
   unit.position = plan.to
+  spendUnitMovement(state, state.currentPhase, unit.id, plan.cost)
 
   const destroyedUnits: string[] = []
   if (plan.capabilities.canRam && plan.ramCapacityUsed > 0) {

--- a/src/engine/movement.ts
+++ b/src/engine/movement.ts
@@ -7,10 +7,11 @@ import logger from '../logger.js'
  */
 
 import type { HexPos, PlayerRole, Command } from '../types/index.js'
-import { isInBounds, findPath, movementCost } from './map.js'
+import { isInBounds } from './map.js'
 import type { GameMap } from './map.js'
 import { getUnitDefinition, onionMovementAllowance, isImmobile } from './units.js'
 import type { GameUnit, DefenderUnit, EngineGameState, OnionUnit } from './units.js'
+import { findMovePath, type MoveMapSnapshot } from '../shared/movePlanner.js'
 
 /**
  * Result of validating a movement command.
@@ -263,7 +264,13 @@ function validateMovePlan(
     return allowance
   }
 
-  const pathResult = findPath(map, unit.position, command.to, allowance.movementAllowance, capabilities.canCrossRidgelines)
+  const pathResult = findMovePath({
+    map: toMoveMapSnapshot(map),
+    from: unit.position,
+    to: command.to,
+    movementAllowance: allowance.movementAllowance,
+    canCrossRidgelines: capabilities.canCrossRidgelines,
+  })
   if (!pathResult.found) {
     return {
       ok: false,
@@ -306,6 +313,18 @@ function validateMovePlan(
       treadCost,
       capabilities,
     },
+  }
+}
+
+function toMoveMapSnapshot(map: GameMap): MoveMapSnapshot {
+  return {
+    width: map.width,
+    height: map.height,
+    hexes: Object.values(map.hexes).map((hex) => ({
+      q: hex.q,
+      r: hex.r,
+      t: hex.terrain === 'ridgeline' ? 1 : hex.terrain === 'crater' ? 2 : 0,
+    })),
   }
 }
 

--- a/src/engine/units.ts
+++ b/src/engine/units.ts
@@ -131,6 +131,8 @@ export interface EngineGameState {
   defenders: Record<string, DefenderUnit>
   /** Number of rams the Onion has performed this turn (max 2) */
   ramsThisTurn: number
+  /** Movement already spent this turn, keyed by phase and unit ID */
+  movementSpent?: Record<string, number>
   /** Current phase of play */
   currentPhase: TurnPhase
   /** Current turn number (1-based) */

--- a/src/engine/units.ts
+++ b/src/engine/units.ts
@@ -6,6 +6,7 @@
 
 import type { HexPos, UnitStatus, TurnPhase } from '../types/index.js'
 import logger from '../logger.js'
+import { onionMovementAllowance } from '../shared/movementAllowance.js'
 
 /**
  * All possible unit types in the game.
@@ -160,17 +161,7 @@ export function getAllUnitDefinitions(): Record<UnitType, UnitDefinition> {
   return { ...UNIT_DEFINITIONS }
 }
 
-/**
- * Calculate movement allowance based on current tread points.
- * @param treads - Current tread points (0-45)
- * @returns Movement allowance (0-3)
- */
-export function onionMovementAllowance(treads: number): number {
-  if (treads === 0) return 0
-  if (treads <= 15) return 1
-  if (treads <= 30) return 2
-  return 3
-}
+export { onionMovementAllowance }
 
 /**
  * Check if a unit can perform a second move (GEV ability).

--- a/src/shared/apiProtocol.ts
+++ b/src/shared/apiProtocol.ts
@@ -42,6 +42,7 @@ export type GameStateResponse = {
 		defender: string
 	}
 	state: GameState
+	movementRemainingByUnit: Record<string, number>
 	scenarioMap?: ScenarioMapSnapshot
 	eventSeq: number
 }

--- a/src/shared/moveFixtures.ts
+++ b/src/shared/moveFixtures.ts
@@ -1,0 +1,66 @@
+import type { GameState } from '../types/index.js'
+
+export function createMoveGameState(treads: number): GameState {
+	return {
+		onion: {
+			id: 'onion-1',
+			type: 'TheOnion',
+			position: { q: 0, r: 1 },
+			treads,
+			status: 'operational',
+			weapons: [
+				{
+					id: 'main-1',
+					name: 'Main Battery',
+					attack: 4,
+					range: 4,
+					defense: 4,
+					status: 'ready',
+					individuallyTargetable: true,
+				},
+			],
+			batteries: {
+				main: 1,
+				secondary: 0,
+				ap: 0,
+			},
+		},
+		defenders: {
+			'wolf-2': {
+				id: 'wolf-2',
+				type: 'BigBadWolf',
+				position: { q: 6, r: 6 },
+				status: 'operational',
+				weapons: [
+					{
+						id: 'main',
+						name: 'Main Gun',
+						attack: 4,
+						range: 2,
+						defense: 2,
+						status: 'ready',
+						individuallyTargetable: false,
+					},
+				],
+			},
+			'puss-1': {
+				id: 'puss-1',
+				type: 'Puss',
+				position: { q: 6, r: 4 },
+				status: 'operational',
+				weapons: [
+					{
+						id: 'main',
+						name: 'Main Gun',
+						attack: 4,
+						range: 2,
+						defense: 3,
+						status: 'ready',
+						individuallyTargetable: false,
+					},
+				],
+			},
+		},
+		ramsThisTurn: 0,
+	}
+}

--- a/src/shared/movePlanner.test.ts
+++ b/src/shared/movePlanner.test.ts
@@ -6,6 +6,13 @@ type MoveMapSnapshot = {
 	width: number
 	height: number
 	hexes: Array<{ q: number; r: number; t: number }>
+	occupiedHexes?: Array<{
+		q: number
+		r: number
+		role: 'onion' | 'defender'
+		unitType: string
+		squads?: number
+	}>
 }
 
 const clearMap: MoveMapSnapshot = {
@@ -31,11 +38,31 @@ describe('movePlanner', () => {
 			to: { q: 2, r: 1 },
 			movementAllowance: 1,
 			canCrossRidgelines: false,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
 		})
 
 		expect(result).toEqual({
 			found: true,
 			path: [{ q: 2, r: 1 }],
+			cost: 1,
+		})
+	})
+
+	it('treats the southeast hex from an odd row as an adjacent move', () => {
+		const result = findMovePath({
+			map: clearMap,
+			from: { q: 1, r: 1 },
+			to: { q: 2, r: 2 },
+			movementAllowance: 1,
+			canCrossRidgelines: false,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
+		})
+
+		expect(result).toEqual({
+			found: true,
+			path: [{ q: 2, r: 2 }],
 			cost: 1,
 		})
 	})
@@ -47,6 +74,8 @@ describe('movePlanner', () => {
 			to: { q: 2, r: 1 },
 			movementAllowance: 2,
 			canCrossRidgelines: true,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
 		})
 
 		expect(result).toEqual({
@@ -63,6 +92,8 @@ describe('movePlanner', () => {
 			to: { q: 2, r: 2 },
 			movementAllowance: 3,
 			canCrossRidgelines: true,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
 		})
 
 		expect(result).toEqual({
@@ -72,12 +103,98 @@ describe('movePlanner', () => {
 		})
 	})
 
+	it('traverses an occupied ally hex en route to a farther destination', () => {
+		const result = findMovePath({
+			map: {
+				...clearMap,
+				occupiedHexes: [{ q: 2, r: 1, role: 'defender', unitType: 'Dragon' }],
+			},
+			from: { q: 1, r: 1 },
+			to: { q: 3, r: 1 },
+			movementAllowance: 3,
+			canCrossRidgelines: false,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
+		})
+
+		expect(result).toEqual({
+			found: true,
+			path: [{ q: 2, r: 1 }, { q: 3, r: 1 }],
+			cost: 2,
+		})
+	})
+
+	it('does not allow a non-Little Pigs unit to stop on an allied occupied destination', () => {
+		const result = findMovePath({
+			map: {
+				...clearMap,
+				occupiedHexes: [{ q: 2, r: 1, role: 'defender', unitType: 'Dragon' }],
+			},
+			from: { q: 1, r: 1 },
+			to: { q: 2, r: 1 },
+			movementAllowance: 1,
+			canCrossRidgelines: false,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
+		})
+
+		expect(result).toEqual({
+			found: false,
+			path: [],
+			cost: 0,
+		})
+	})
+
+	it('allows Little Pigs to stack on an allied Little Pigs hex', () => {
+		const result = findMovePath({
+			map: {
+				...clearMap,
+				occupiedHexes: [{ q: 2, r: 1, role: 'defender', unitType: 'LittlePigs', squads: 1 }],
+			},
+			from: { q: 1, r: 1 },
+			to: { q: 2, r: 1 },
+			movementAllowance: 1,
+			canCrossRidgelines: false,
+			movingRole: 'defender',
+			movingUnitType: 'LittlePigs',
+		})
+
+		expect(result).toEqual({
+			found: true,
+			path: [{ q: 2, r: 1 }],
+			cost: 1,
+		})
+	})
+
+	it('treats enemy occupied hexes as traversable for the Onion', () => {
+		const result = findMovePath({
+			map: {
+				...clearMap,
+				occupiedHexes: [{ q: 2, r: 1, role: 'defender', unitType: 'Puss' }],
+			},
+			from: { q: 1, r: 1 },
+			to: { q: 3, r: 1 },
+			movementAllowance: 3,
+			canCrossRidgelines: false,
+			movingRole: 'onion',
+			movingUnitType: 'TheOnion',
+		})
+
+		expect(result).toEqual({
+			found: true,
+			path: [{ q: 2, r: 1 }, { q: 3, r: 1 }],
+			cost: 2,
+		})
+	})
+
 	it('lists all reachable neighbors from the center of a clear board', () => {
 		const result = listReachableMoves({
 			map: clearMap,
 			from: { q: 1, r: 1 },
 			movementAllowance: 1,
 			canCrossRidgelines: false,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
 		})
 
 		expect(result).toHaveLength(6)
@@ -92,9 +209,27 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			movementAllowance: 1,
 			canCrossRidgelines: false,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
 		})
 
 		expect(result.find((move) => move.to.q === 2 && move.to.r === 1)).toBeUndefined()
 		expect(result.find((move) => move.to.q === 2 && move.to.r === 2)).toBeUndefined()
+	})
+
+	it('omits occupied hexes from normal reachable moves', () => {
+		const result = listReachableMoves({
+			map: {
+				...clearMap,
+				occupiedHexes: [{ q: 2, r: 1, role: 'defender', unitType: 'Dragon' }],
+			},
+			from: { q: 1, r: 1 },
+			movementAllowance: 3,
+			canCrossRidgelines: false,
+			movingRole: 'defender',
+			movingUnitType: 'Puss',
+		})
+
+		expect(result.find((move) => move.to.q === 2 && move.to.r === 1)).toBeUndefined()
 	})
 })

--- a/src/shared/movePlanner.test.ts
+++ b/src/shared/movePlanner.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { findMovePath, listReachableMoves } from './movePlanner.js'
+
+type MoveMapSnapshot = {
+	width: number
+	height: number
+	hexes: Array<{ q: number; r: number; t: number }>
+}
+
+const clearMap: MoveMapSnapshot = {
+	width: 4,
+	height: 4,
+	hexes: [],
+}
+
+const terrainMap: MoveMapSnapshot = {
+	width: 4,
+	height: 4,
+	hexes: [
+		{ q: 2, r: 1, t: 1 },
+		{ q: 2, r: 2, t: 2 },
+	],
+}
+
+describe('movePlanner', () => {
+	it('returns a path and cost for a reachable destination on clear terrain', () => {
+		const result = findMovePath({
+			map: clearMap,
+			from: { q: 1, r: 1 },
+			to: { q: 2, r: 1 },
+			movementAllowance: 1,
+			canCrossRidgelines: false,
+		})
+
+		expect(result).toEqual({
+			found: true,
+			path: [{ q: 2, r: 1 }],
+			cost: 1,
+		})
+	})
+
+	it('treats ridgelines as cost 2 when the unit can cross them', () => {
+		const result = findMovePath({
+			map: terrainMap,
+			from: { q: 1, r: 1 },
+			to: { q: 2, r: 1 },
+			movementAllowance: 2,
+			canCrossRidgelines: true,
+		})
+
+		expect(result).toEqual({
+			found: true,
+			path: [{ q: 2, r: 1 }],
+			cost: 2,
+		})
+	})
+
+	it('returns no path when a crater blocks the destination', () => {
+		const result = findMovePath({
+			map: terrainMap,
+			from: { q: 1, r: 1 },
+			to: { q: 2, r: 2 },
+			movementAllowance: 3,
+			canCrossRidgelines: true,
+		})
+
+		expect(result).toEqual({
+			found: false,
+			path: [],
+			cost: 0,
+		})
+	})
+
+	it('lists all reachable neighbors from the center of a clear board', () => {
+		const result = listReachableMoves({
+			map: clearMap,
+			from: { q: 1, r: 1 },
+			movementAllowance: 1,
+			canCrossRidgelines: false,
+		})
+
+		expect(result).toHaveLength(6)
+		expect(result).toContainEqual({ to: { q: 2, r: 1 }, path: [{ q: 2, r: 1 }], cost: 1 })
+		expect(result).toContainEqual({ to: { q: 0, r: 1 }, path: [{ q: 0, r: 1 }], cost: 1 })
+		expect(result).toContainEqual({ to: { q: 1, r: 2 }, path: [{ q: 1, r: 2 }], cost: 1 })
+	})
+
+	it('omits ridgelines and craters that exceed the current allowance', () => {
+		const result = listReachableMoves({
+			map: terrainMap,
+			from: { q: 1, r: 1 },
+			movementAllowance: 1,
+			canCrossRidgelines: false,
+		})
+
+		expect(result.find((move) => move.to.q === 2 && move.to.r === 1)).toBeUndefined()
+		expect(result.find((move) => move.to.q === 2 && move.to.r === 2)).toBeUndefined()
+	})
+})

--- a/src/shared/movePlanner.ts
+++ b/src/shared/movePlanner.ts
@@ -4,6 +4,13 @@ export type MoveMapSnapshot = {
 	width: number
 	height: number
 	hexes: Array<{ q: number; r: number; t: number }>
+	occupiedHexes?: Array<{
+		q: number
+		r: number
+		role: 'onion' | 'defender'
+		unitType: string
+		squads?: number
+	}>
 }
 
 export type ReachableMove = {
@@ -13,6 +20,10 @@ export type ReachableMove = {
 }
 
 type TerrainType = 'clear' | 'ridgeline' | 'crater'
+
+type MoveRole = 'onion' | 'defender'
+
+type Occupant = NonNullable<MoveMapSnapshot['occupiedHexes']>[number]
 
 function hexKey(pos: HexPos): string {
 	return `${pos.q},${pos.r}`
@@ -38,13 +49,70 @@ function getTerrainLookup(map: MoveMapSnapshot): Map<string, TerrainType> {
 	return new Map(map.hexes.map((hex) => [hexKey(hex), terrainFromT(hex.t)]))
 }
 
+function getOccupiedLookup(map: MoveMapSnapshot): Map<string, Occupant[]> {
+	const lookup = new Map<string, Occupant[]>()
+	for (const occupant of map.occupiedHexes ?? []) {
+		const key = hexKey(occupant)
+		const occupants = lookup.get(key) ?? []
+		occupants.push(occupant)
+		lookup.set(key, occupants)
+	}
+	return lookup
+}
+
+function canTraverseOccupiedHex(movingRole: MoveRole, occupants: Occupant[]): boolean {
+	if (occupants.length === 0) {
+		return true
+	}
+
+	if (movingRole === 'onion') {
+		return occupants.some((occupant) => occupant.role === 'defender')
+	}
+
+	return occupants.every((occupant) => occupant.role === 'defender')
+}
+
+function canStopOnOccupiedHex(movingRole: MoveRole, movingUnitType: string, occupants: Occupant[]): boolean {
+	if (occupants.length === 0) {
+		return true
+	}
+
+	if (movingRole === 'onion') {
+		return occupants.every((occupant) => occupant.role === 'defender')
+	}
+
+	const isLittlePigs = movingUnitType === 'LittlePigs'
+	if (!isLittlePigs) {
+		return false
+	}
+
+	if (!occupants.every((occupant) => occupant.role === 'defender' && occupant.unitType === 'LittlePigs')) {
+		return false
+	}
+
+	const incomingSquads = 1
+	const destinationSquads = occupants.reduce((total, occupant) => total + (occupant.squads ?? 1), 0)
+	return incomingSquads + destinationSquads <= 3
+}
+
 function getNeighbors(pos: HexPos): HexPos[] {
+	if (pos.r & 1) {
+		return [
+			{ q: pos.q + 1, r: pos.r },
+			{ q: pos.q - 1, r: pos.r },
+			{ q: pos.q + 1, r: pos.r - 1 },
+			{ q: pos.q, r: pos.r - 1 },
+			{ q: pos.q + 1, r: pos.r + 1 },
+			{ q: pos.q, r: pos.r + 1 },
+		]
+	}
+
 	return [
 		{ q: pos.q + 1, r: pos.r },
 		{ q: pos.q - 1, r: pos.r },
-		{ q: pos.q, r: pos.r + 1 },
 		{ q: pos.q, r: pos.r - 1 },
-		{ q: pos.q + 1, r: pos.r - 1 },
+		{ q: pos.q - 1, r: pos.r - 1 },
+		{ q: pos.q, r: pos.r + 1 },
 		{ q: pos.q - 1, r: pos.r + 1 },
 	]
 }
@@ -66,8 +134,10 @@ function exploreReachableMoves(
 	from: HexPos,
 	movementAllowance: number,
 	canCrossRidgelines: boolean,
+	movingRole: MoveRole,
 ) {
 	const terrainLookup = getTerrainLookup(map)
+	const occupiedLookup = getOccupiedLookup(map)
 	const dist = new Map<string, number>()
 	const prev = new Map<string, HexPos | null>()
 	const queue: Array<{ pos: HexPos; cost: number }> = [{ pos: from, cost: 0 }]
@@ -81,6 +151,8 @@ function exploreReachableMoves(
 
 		for (const neighbor of getNeighbors(pos)) {
 			if (!isInBounds(map, neighbor)) continue
+			const neighborOccupants = occupiedLookup.get(hexKey(neighbor)) ?? []
+			if (!canTraverseOccupiedHex(movingRole, neighborOccupants)) continue
 
 			const terrain = terrainLookup.get(hexKey(neighbor)) ?? 'clear'
 			const stepCost = terrainCost(terrain, canCrossRidgelines)
@@ -107,6 +179,8 @@ export function findMovePath(input: {
 	to: HexPos
 	movementAllowance: number
 	canCrossRidgelines: boolean
+	movingRole: MoveRole
+	movingUnitType: string
 }): { found: true; path: HexPos[]; cost: number } | { found: false; path: []; cost: 0 } {
 	if (!isInBounds(input.map, input.to)) {
 		return { found: false, path: [], cost: 0 }
@@ -117,6 +191,7 @@ export function findMovePath(input: {
 	}
 
 	const terrainLookup = getTerrainLookup(input.map)
+	const occupiedLookup = getOccupiedLookup(input.map)
 	const dist = new Map<string, number>()
 	const prev = new Map<string, HexPos | null>()
 	const queue: Array<{ pos: HexPos; cost: number }> = [{ pos: input.from, cost: 0 }]
@@ -127,13 +202,16 @@ export function findMovePath(input: {
 	while (queue.length > 0) {
 		queue.sort((a, b) => a.cost - b.cost)
 		const { pos, cost } = queue.shift()!
+		const currentOccupants = occupiedLookup.get(hexKey(pos)) ?? []
 
-		if (pos.q === input.to.q && pos.r === input.to.r) {
+		if (pos.q === input.to.q && pos.r === input.to.r && canStopOnOccupiedHex(input.movingRole, input.movingUnitType, currentOccupants)) {
 			return { found: true, path: reconstructPath(prev, input.from, input.to), cost }
 		}
 
 		for (const neighbor of getNeighbors(pos)) {
 			if (!isInBounds(input.map, neighbor)) continue
+			const neighborOccupants = occupiedLookup.get(hexKey(neighbor)) ?? []
+			if (!canTraverseOccupiedHex(input.movingRole, neighborOccupants)) continue
 
 			const terrain = terrainLookup.get(hexKey(neighbor)) ?? 'clear'
 			const stepCost = terrainCost(terrain, input.canCrossRidgelines)
@@ -159,8 +237,11 @@ export function listReachableMoves(input: {
 	from: HexPos
 	movementAllowance: number
 	canCrossRidgelines: boolean
+	movingRole: MoveRole
+	movingUnitType: string
 }): ReachableMove[] {
-	const { dist, prev } = exploreReachableMoves(input.map, input.from, input.movementAllowance, input.canCrossRidgelines)
+	const { dist, prev } = exploreReachableMoves(input.map, input.from, input.movementAllowance, input.canCrossRidgelines, input.movingRole)
+	const occupiedLookup = getOccupiedLookup(input.map)
 
 	const moves: ReachableMove[] = []
 	for (const [key, cost] of dist.entries()) {
@@ -168,6 +249,10 @@ export function listReachableMoves(input: {
 
 		const [q, r] = key.split(',').map(Number)
 		const to = { q, r }
+		const occupants = occupiedLookup.get(key) ?? []
+		if (!canStopOnOccupiedHex(input.movingRole, input.movingUnitType, occupants)) {
+			continue
+		}
 		moves.push({
 			to,
 			cost,

--- a/src/shared/movePlanner.ts
+++ b/src/shared/movePlanner.ts
@@ -1,0 +1,179 @@
+import type { HexPos } from '../types/index.js'
+
+export type MoveMapSnapshot = {
+	width: number
+	height: number
+	hexes: Array<{ q: number; r: number; t: number }>
+}
+
+export type ReachableMove = {
+	to: HexPos
+	path: HexPos[]
+	cost: number
+}
+
+type TerrainType = 'clear' | 'ridgeline' | 'crater'
+
+function hexKey(pos: HexPos): string {
+	return `${pos.q},${pos.r}`
+}
+
+function terrainFromT(t: number): TerrainType {
+	if (t === 1) return 'ridgeline'
+	if (t === 2) return 'crater'
+	return 'clear'
+}
+
+function terrainCost(terrain: TerrainType, canCrossRidgelines: boolean): number | null {
+	if (terrain === 'crater') return null
+	if (terrain === 'ridgeline') return canCrossRidgelines ? 2 : null
+	return 1
+}
+
+function isInBounds(map: MoveMapSnapshot, pos: HexPos): boolean {
+	return pos.q >= 0 && pos.q < map.width && pos.r >= 0 && pos.r < map.height
+}
+
+function getTerrainLookup(map: MoveMapSnapshot): Map<string, TerrainType> {
+	return new Map(map.hexes.map((hex) => [hexKey(hex), terrainFromT(hex.t)]))
+}
+
+function getNeighbors(pos: HexPos): HexPos[] {
+	return [
+		{ q: pos.q + 1, r: pos.r },
+		{ q: pos.q - 1, r: pos.r },
+		{ q: pos.q, r: pos.r + 1 },
+		{ q: pos.q, r: pos.r - 1 },
+		{ q: pos.q + 1, r: pos.r - 1 },
+		{ q: pos.q - 1, r: pos.r + 1 },
+	]
+}
+
+function reconstructPath(prev: Map<string, HexPos | null>, from: HexPos, to: HexPos): HexPos[] {
+	const path: HexPos[] = []
+	let cursor: HexPos | null = to
+
+	while (cursor && !(cursor.q === from.q && cursor.r === from.r)) {
+		path.unshift(cursor)
+		cursor = prev.get(hexKey(cursor)) ?? null
+	}
+
+	return path
+}
+
+function exploreReachableMoves(
+	map: MoveMapSnapshot,
+	from: HexPos,
+	movementAllowance: number,
+	canCrossRidgelines: boolean,
+) {
+	const terrainLookup = getTerrainLookup(map)
+	const dist = new Map<string, number>()
+	const prev = new Map<string, HexPos | null>()
+	const queue: Array<{ pos: HexPos; cost: number }> = [{ pos: from, cost: 0 }]
+
+	dist.set(hexKey(from), 0)
+	prev.set(hexKey(from), null)
+
+	while (queue.length > 0) {
+		queue.sort((a, b) => a.cost - b.cost)
+		const { pos, cost } = queue.shift()!
+
+		for (const neighbor of getNeighbors(pos)) {
+			if (!isInBounds(map, neighbor)) continue
+
+			const terrain = terrainLookup.get(hexKey(neighbor)) ?? 'clear'
+			const stepCost = terrainCost(terrain, canCrossRidgelines)
+			if (stepCost === null) continue
+
+			const newCost = cost + stepCost
+			if (newCost > movementAllowance) continue
+
+			const key = hexKey(neighbor)
+			if (dist.has(key) && dist.get(key)! <= newCost) continue
+
+			dist.set(key, newCost)
+			prev.set(key, pos)
+			queue.push({ pos: neighbor, cost: newCost })
+		}
+	}
+
+	return { dist, prev }
+}
+
+export function findMovePath(input: {
+	map: MoveMapSnapshot
+	from: HexPos
+	to: HexPos
+	movementAllowance: number
+	canCrossRidgelines: boolean
+}): { found: true; path: HexPos[]; cost: number } | { found: false; path: []; cost: 0 } {
+	if (!isInBounds(input.map, input.to)) {
+		return { found: false, path: [], cost: 0 }
+	}
+
+	if (input.from.q === input.to.q && input.from.r === input.to.r) {
+		return { found: true, path: [], cost: 0 }
+	}
+
+	const terrainLookup = getTerrainLookup(input.map)
+	const dist = new Map<string, number>()
+	const prev = new Map<string, HexPos | null>()
+	const queue: Array<{ pos: HexPos; cost: number }> = [{ pos: input.from, cost: 0 }]
+
+	dist.set(hexKey(input.from), 0)
+	prev.set(hexKey(input.from), null)
+
+	while (queue.length > 0) {
+		queue.sort((a, b) => a.cost - b.cost)
+		const { pos, cost } = queue.shift()!
+
+		if (pos.q === input.to.q && pos.r === input.to.r) {
+			return { found: true, path: reconstructPath(prev, input.from, input.to), cost }
+		}
+
+		for (const neighbor of getNeighbors(pos)) {
+			if (!isInBounds(input.map, neighbor)) continue
+
+			const terrain = terrainLookup.get(hexKey(neighbor)) ?? 'clear'
+			const stepCost = terrainCost(terrain, input.canCrossRidgelines)
+			if (stepCost === null) continue
+
+			const newCost = cost + stepCost
+			if (newCost > input.movementAllowance) continue
+
+			const key = hexKey(neighbor)
+			if (dist.has(key) && dist.get(key)! <= newCost) continue
+
+			dist.set(key, newCost)
+			prev.set(key, pos)
+			queue.push({ pos: neighbor, cost: newCost })
+		}
+	}
+
+	return { found: false, path: [], cost: 0 }
+}
+
+export function listReachableMoves(input: {
+	map: MoveMapSnapshot
+	from: HexPos
+	movementAllowance: number
+	canCrossRidgelines: boolean
+}): ReachableMove[] {
+	const { dist, prev } = exploreReachableMoves(input.map, input.from, input.movementAllowance, input.canCrossRidgelines)
+
+	const moves: ReachableMove[] = []
+	for (const [key, cost] of dist.entries()) {
+		if (key === hexKey(input.from)) continue
+
+		const [q, r] = key.split(',').map(Number)
+		const to = { q, r }
+		moves.push({
+			to,
+			cost,
+			path: reconstructPath(prev, input.from, to),
+		})
+	}
+
+	return moves.sort((a, b) => a.cost - b.cost || a.to.q - b.to.q || a.to.r - b.to.r)
+}

--- a/src/shared/movementAllowance.test.ts
+++ b/src/shared/movementAllowance.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { onionMovementAllowance } from './movementAllowance.js'
+
+describe('onionMovementAllowance', () => {
+	it('returns 0 when the Onion has no treads left', () => {
+		expect(onionMovementAllowance(0)).toBe(0)
+	})
+
+	it('returns 1 at the first movement band', () => {
+		expect(onionMovementAllowance(15)).toBe(1)
+	})
+
+	it('returns 2 when the Onion crosses into the middle movement band', () => {
+		expect(onionMovementAllowance(16)).toBe(2)
+	})
+
+	it('returns 2 at the upper middle bound', () => {
+		expect(onionMovementAllowance(30)).toBe(2)
+	})
+
+	it('returns 3 when the Onion reaches the top movement band', () => {
+		expect(onionMovementAllowance(31)).toBe(3)
+	})
+})

--- a/src/shared/movementAllowance.ts
+++ b/src/shared/movementAllowance.ts
@@ -1,0 +1,6 @@
+export function onionMovementAllowance(treads: number): number {
+	if (treads <= 0) return 0
+	if (treads <= 15) return 1
+	if (treads <= 30) return 2
+	return 3
+}

--- a/src/shared/unitMovement.test.ts
+++ b/src/shared/unitMovement.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { canUnitCrossRidgelines, canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, isUnitImmobile, spendUnitMovement } from './unitMovement.js'
+
+describe('unit movement helpers', () => {
+	it('returns Onion movement allowance by tread band during the movement phase', () => {
+		expect(getUnitMovementAllowance('TheOnion', 'ONION_MOVE', 0)).toBe(0)
+		expect(getUnitMovementAllowance('TheOnion', 'ONION_MOVE', 15)).toBe(1)
+		expect(getUnitMovementAllowance('TheOnion', 'ONION_MOVE', 16)).toBe(2)
+		expect(getUnitMovementAllowance('TheOnion', 'ONION_MOVE', 31)).toBe(3)
+	})
+
+	it('returns 0 for Onion outside the movement phase', () => {
+		expect(getUnitMovementAllowance('TheOnion', 'ONION_COMBAT', 45)).toBe(0)
+	})
+
+	it('returns defender movement allowance during defender movement', () => {
+		expect(getUnitMovementAllowance('Puss', 'DEFENDER_MOVE')).toBe(3)
+		expect(getUnitMovementAllowance('Witch', 'DEFENDER_MOVE')).toBe(2)
+		expect(getUnitMovementAllowance('Dragon', 'DEFENDER_MOVE')).toBe(5)
+	})
+
+	it('returns GEV second-move allowance only during the second move phase', () => {
+		expect(getUnitMovementAllowance('BigBadWolf', 'DEFENDER_MOVE')).toBe(4)
+		expect(getUnitMovementAllowance('BigBadWolf', 'GEV_SECOND_MOVE')).toBe(3)
+		expect(getUnitMovementAllowance('Puss', 'GEV_SECOND_MOVE')).toBe(0)
+		expect(canUnitSecondMove('BigBadWolf')).toBe(true)
+		expect(canUnitSecondMove('Puss')).toBe(false)
+	})
+
+	it('reports the ridge-crossing capability and immobility per unit type', () => {
+		expect(canUnitCrossRidgelines('TheOnion')).toBe(true)
+		expect(canUnitCrossRidgelines('LittlePigs')).toBe(true)
+		expect(canUnitCrossRidgelines('Puss')).toBe(false)
+		expect(isUnitImmobile('LordFarquaad')).toBe(true)
+		expect(isUnitImmobile('Puss')).toBe(false)
+	})
+
+	it('tracks remaining movement after spending hexes in the current phase', () => {
+		const state = { movementSpent: {} }
+
+		expect(getRemainingUnitMovementAllowance('Puss', 'DEFENDER_MOVE', state, 'wolf-2')).toBe(3)
+		spendUnitMovement(state, 'DEFENDER_MOVE', 'wolf-2', 1)
+		expect(getRemainingUnitMovementAllowance('Puss', 'DEFENDER_MOVE', state, 'wolf-2')).toBe(2)
+		spendUnitMovement(state, 'DEFENDER_MOVE', 'wolf-2', 2)
+		expect(getRemainingUnitMovementAllowance('Puss', 'DEFENDER_MOVE', state, 'wolf-2')).toBe(0)
+	})
+
+	it('keeps GEV second move separate from defender move spending', () => {
+		const state = { movementSpent: {} }
+
+		spendUnitMovement(state, 'DEFENDER_MOVE', 'wolf-2', 3)
+		expect(getRemainingUnitMovementAllowance('BigBadWolf', 'GEV_SECOND_MOVE', state, 'wolf-2')).toBe(3)
+	})
+})

--- a/src/shared/unitMovement.ts
+++ b/src/shared/unitMovement.ts
@@ -1,0 +1,92 @@
+import type { GameState, TurnPhase } from '../types/index.js'
+import { onionMovementAllowance } from './movementAllowance.js'
+
+type MovementProfile = {
+	movement: number
+	canCrossRidgelines?: boolean
+	secondMoveAllowance?: number
+	secondMove?: boolean
+	immobile?: boolean
+}
+
+const MOVEMENT_PROFILES: Record<string, MovementProfile> = {
+	TheOnion: { movement: 3, canCrossRidgelines: true },
+	BigBadWolf: { movement: 4, secondMoveAllowance: 3, secondMove: true },
+	Puss: { movement: 3 },
+	Witch: { movement: 2 },
+	LordFarquaad: { movement: 0, immobile: true },
+	Pinocchio: { movement: 2 },
+	Dragon: { movement: 5 },
+	LittlePigs: { movement: 1, canCrossRidgelines: true },
+	Castle: { movement: 0, immobile: true },
+}
+
+function getProfile(unitType: string): MovementProfile {
+	return MOVEMENT_PROFILES[unitType] ?? { movement: 0 }
+}
+
+function movementSpentKey(phase: TurnPhase, unitId: string): string {
+	return `${phase}:${unitId}`
+}
+
+export function canUnitCrossRidgelines(unitType: string): boolean {
+	return getProfile(unitType).canCrossRidgelines === true
+}
+
+export function canUnitSecondMove(unitType: string): boolean {
+	return getProfile(unitType).secondMove === true
+}
+
+export function isUnitImmobile(unitType: string): boolean {
+	return getProfile(unitType).immobile === true
+}
+
+export function getUnitMovementAllowance(unitType: string, phase: TurnPhase, treads?: number): number {
+	const profile = getProfile(unitType)
+
+	if (unitType === 'TheOnion') {
+		if (phase !== 'ONION_MOVE') {
+			return 0
+		}
+
+		return onionMovementAllowance(treads ?? 0)
+	}
+
+	if (phase === 'GEV_SECOND_MOVE') {
+		return canUnitSecondMove(unitType) ? profile.secondMoveAllowance ?? 0 : 0
+	}
+
+	if (phase !== 'DEFENDER_MOVE') {
+		return 0
+	}
+
+	return profile.movement
+}
+
+export function getUnitMovementSpent(state: Pick<GameState, 'movementSpent'> | null | undefined, phase: TurnPhase, unitId: string): number {
+	return state?.movementSpent?.[movementSpentKey(phase, unitId)] ?? 0
+}
+
+export function getRemainingUnitMovementAllowance(
+	unitType: string,
+	phase: TurnPhase,
+	state: Pick<GameState, 'movementSpent'> | null | undefined,
+	unitId: string,
+	treads?: number,
+): number {
+	return Math.max(getUnitMovementAllowance(unitType, phase, treads) - getUnitMovementSpent(state, phase, unitId), 0)
+}
+
+export function spendUnitMovement(state: Pick<GameState, 'movementSpent'>, phase: TurnPhase, unitId: string, spent: number): void {
+	if (spent <= 0) {
+		return
+	}
+
+	state.movementSpent ??= {}
+	const key = movementSpentKey(phase, unitId)
+	state.movementSpent[key] = (state.movementSpent[key] ?? 0) + spent
+}
+
+export function resetMovementSpent(state: Pick<GameState, 'movementSpent'>): void {
+	state.movementSpent = {}
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,7 @@ export interface GameState {
   }
   defenders: Record<string, DefenderUnit>
   ramsThisTurn?: number
+  movementSpent?: Record<string, number>
 }
 
 export interface EventEnvelope {
@@ -76,6 +77,7 @@ export interface ActionOkResponse {
   seq: number
   events: EventEnvelope[]
   state: GameState
+  movementRemainingByUnit: Record<string, number>
 }
 
 /**

--- a/web/src/App.orchestration.test.tsx
+++ b/web/src/App.orchestration.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -79,6 +79,10 @@ function createAuthoritativeBattlefieldSnapshot(): AuthoritativeBattlefieldSnaps
 			},
 			ramsThisTurn: 0,
 		},
+			movementRemainingByUnit: {
+				'onion-live': 0,
+				'dragon-7': 0,
+			},
 		scenarioMap: {
 			width: 2,
 			height: 2,
@@ -160,6 +164,11 @@ function createConnectedBattlefieldSnapshot(
 			},
 			ramsThisTurn: 0,
 		},
+			movementRemainingByUnit: {
+				'onion-1': 0,
+				'wolf-2': 4,
+				'puss-1': 3,
+			},
 		scenarioMap: {
 			width: 8,
 			height: 8,
@@ -169,10 +178,16 @@ function createConnectedBattlefieldSnapshot(
 	}
 }
 
-function createSnapshotWithTreads(treads: number): AuthoritativeBattlefieldSnapshot {
+function createSnapshotWithTreads(treads: number, movementRemaining: number): AuthoritativeBattlefieldSnapshot {
 	return {
 		...createConnectedBattlefieldSnapshot(),
+		phase: 'ONION_MOVE',
 		authoritativeState: createMoveGameState(treads),
+		movementRemainingByUnit: {
+			'onion-1': movementRemaining,
+			'wolf-2': 4,
+			'puss-1': 3,
+		},
 	}
 }
 
@@ -213,24 +228,8 @@ describe('App orchestration (injected game client)', () => {
 		expect(screen.queryByText('14,21')).toBeNull()
 	})
 
-	it('derives onion move allowance from the shared helper at the first band', async () => {
-		const snapshot = createSnapshotWithTreads(15)
-		const session = { role: 'defender' as const }
-
-		const client = createGameClient({
-			getState: vi.fn().mockResolvedValue({ snapshot, session }),
-			submitAction: vi.fn().mockResolvedValue(snapshot),
-			pollEvents: vi.fn().mockResolvedValue([]),
-		})
-
-		render(<App gameClient={client} gameId={123} />)
-
-		const onionCard = await screen.findByRole('button', { name: /onion-1/i })
-		expect(onionCard.textContent).toContain('Moves 1')
-	})
-
-	it('derives onion move allowance from the shared helper at the second band', async () => {
-		const snapshot = createSnapshotWithTreads(16)
+	it('renders backend-provided onion movement remaining at the first band', async () => {
+		const snapshot = createSnapshotWithTreads(15, 2)
 		const session = { role: 'defender' as const }
 
 		const client = createGameClient({
@@ -245,11 +244,27 @@ describe('App orchestration (injected game client)', () => {
 		expect(onionCard.textContent).toContain('Moves 2')
 	})
 
-	it('calls commitClientAction on unit select and updates UI', async () => {
+	it('renders backend-provided onion movement remaining at the second band', async () => {
+		const snapshot = createSnapshotWithTreads(16, 1)
+		const session = { role: 'defender' as const }
+
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} />)
+
+		const onionCard = await screen.findByRole('button', { name: /onion-1/i })
+		expect(onionCard.textContent).toContain('Moves 1')
+	})
+
+	it('selects a unit locally without submitting an action', async () => {
 		const user = userEvent.setup()
 		const snapshot = createConnectedBattlefieldSnapshot()
 		const session = { role: 'defender' as const }
-		const submitAction = vi.fn().mockResolvedValue({ ...snapshot, selectedUnitId: 'puss-1' })
+		const submitAction = vi.fn().mockResolvedValue(snapshot)
 
 		const client = createGameClient({
 			getState: vi.fn().mockResolvedValue({ snapshot, session }),
@@ -263,11 +278,11 @@ describe('App orchestration (injected game client)', () => {
 
 		await user.click(screen.getByRole('button', { name: /puss-1/i }))
 
-		expect(submitAction).toHaveBeenCalledWith(123, { type: 'select-unit', unitId: 'puss-1' })
 		await screen.findByText(/Selected unit: puss-1/i)
+		expect(submitAction).not.toHaveBeenCalled()
 	})
 
-	it('surfaces errors from commitClientAction as a banner', async () => {
+	it('surfaces errors from move submission as a banner', async () => {
 		const user = userEvent.setup()
 		const snapshot = createConnectedBattlefieldSnapshot()
 		const session = { role: 'defender' as const }
@@ -284,12 +299,60 @@ describe('App orchestration (injected game client)', () => {
 
 		await screen.findByText(/Selected unit: wolf-2/i)
 
-		await user.click(screen.getByRole('button', { name: /puss-1/i }))
+		await user.click(screen.getByRole('button', { name: /toggle debug diagnostics/i }))
+		await user.click(screen.getByRole('button', { name: /advance phase/i }))
 
 		await screen.findByRole('alert')
 		expect(screen.getByRole('alert').textContent).toMatch(/Failed to submit action/i)
 		expect(screen.getByRole('alert').textContent).toMatch(/mock transport failure/i)
 	})
+
+	it('submits a move when the active player right-clicks an in-range hex', async () => {
+		const snapshot = createConnectedBattlefieldSnapshot({
+			phase: 'DEFENDER_MOVE',
+			selectedUnitId: 'wolf-2',
+		})
+		const session = { role: 'defender' as const }
+		const submitAction = vi.fn().mockResolvedValue(snapshot)
+
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session }),
+			submitAction,
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} />)
+
+		await screen.findByText(/Selected unit: wolf-2/i)
+
+		fireEvent.contextMenu(screen.getByTestId('hex-cell-7-6'))
+
+		expect(submitAction).toHaveBeenCalledWith(123, { type: 'MOVE', unitId: 'wolf-2', to: { q: 7, r: 6 } })
+	})
+
+	it('does not submit a move when the player is inactive', async () => {
+		const snapshot = createConnectedBattlefieldSnapshot({
+			phase: 'DEFENDER_MOVE',
+			selectedUnitId: 'wolf-2',
+		})
+		const session = { role: 'onion' as const }
+		const submitAction = vi.fn().mockResolvedValue(snapshot)
+
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session }),
+			submitAction,
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} />)
+
+		await screen.findByText(/Selected unit: wolf-2/i)
+
+		fireEvent.contextMenu(screen.getByTestId('hex-cell-7-6'))
+
+		expect(submitAction).not.toHaveBeenCalled()
+	})
+
 	it('renders from the current game snapshot', async () => {
 		const snapshot = createConnectedBattlefieldSnapshot({
 			selectedUnitId: 'puss-1',

--- a/web/src/App.orchestration.test.tsx
+++ b/web/src/App.orchestration.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 import App from './App'
 import { createGameClient, type GameSnapshot } from './lib/gameClient'
 import type { GameState } from '../../src/types/index'
+import { createMoveGameState } from '../../src/shared/moveFixtures'
 
 type AuthoritativeBattlefieldSnapshot = GameSnapshot & {
 	authoritativeState: GameState
@@ -168,6 +169,13 @@ function createConnectedBattlefieldSnapshot(
 	}
 }
 
+function createSnapshotWithTreads(treads: number): AuthoritativeBattlefieldSnapshot {
+	return {
+		...createConnectedBattlefieldSnapshot(),
+		authoritativeState: createMoveGameState(treads),
+	}
+}
+
 describe('App orchestration (injected game client)', () => {
 	it('renders defender roster and inspector details from authoritative game state instead of mock battlefield data', async () => {
 		const snapshot = createAuthoritativeBattlefieldSnapshot()
@@ -203,6 +211,38 @@ describe('App orchestration (injected game client)', () => {
 		expect(screen.getByText('1,1')).not.toBeNull()
 		expect(screen.queryByText('2,1')).toBeNull()
 		expect(screen.queryByText('14,21')).toBeNull()
+	})
+
+	it('derives onion move allowance from the shared helper at the first band', async () => {
+		const snapshot = createSnapshotWithTreads(15)
+		const session = { role: 'defender' as const }
+
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} />)
+
+		const onionCard = await screen.findByRole('button', { name: /onion-1/i })
+		expect(onionCard.textContent).toContain('Moves 1')
+	})
+
+	it('derives onion move allowance from the shared helper at the second band', async () => {
+		const snapshot = createSnapshotWithTreads(16)
+		const session = { role: 'defender' as const }
+
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} />)
+
+		const onionCard = await screen.findByRole('button', { name: /onion-1/i })
+		expect(onionCard.textContent).toContain('Moves 2')
 	})
 
 	it('calls commitClientAction on unit select and updates UI', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import {
 import { createHttpGameClient } from './lib/httpGameClient'
 import type { WebRuntimeConfig } from './lib/appBootstrap'
 import { requestJson } from '../../src/shared/apiProtocol'
+import { onionMovementAllowance } from '../../src/shared/movementAllowance'
 import type { GameState, TurnPhase, UnitStatus, Weapon } from '../../src/types/index'
 import './App.css'
 
@@ -99,22 +100,6 @@ function formatAttackSummary(weapons: ReadonlyArray<Weapon> | undefined) {
   return `${primaryWeapon.attack} / rng ${primaryWeapon.range}`
 }
 
-function getOnionMovementAllowance(treads: number) {
-  if (treads === 0) {
-    return 0
-  }
-
-  if (treads <= 15) {
-    return 1
-  }
-
-  if (treads <= 30) {
-    return 2
-  }
-
-  return 3
-}
-
 function getActionableModes(status: UnitStatus | undefined, weapons: ReadonlyArray<Weapon> | undefined, activeTurnActive: boolean): Mode[] {
   if (!activeTurnActive || status === 'destroyed' || status === 'disabled') {
     return []
@@ -140,7 +125,7 @@ function buildLiveDefenders(authoritativeState: GameState, activeTurnActive: boo
 
 function buildLiveOnion(authoritativeState: GameState): BattlefieldOnionView {
   const onion = authoritativeState.onion
-  const movesAllowed = getOnionMovementAllowance(onion.treads)
+  const movesAllowed = onionMovementAllowance(onion.treads)
 
   return {
     id: onion.id ?? 'onion-1',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,8 +18,8 @@ import {
 import { createHttpGameClient } from './lib/httpGameClient'
 import type { WebRuntimeConfig } from './lib/appBootstrap'
 import { requestJson } from '../../src/shared/apiProtocol'
-import { onionMovementAllowance } from '../../src/shared/movementAllowance'
-import type { GameState, TurnPhase, UnitStatus, Weapon } from '../../src/types/index'
+import { getUnitMovementAllowance } from '../../src/shared/unitMovement'
+import type { TurnPhase, UnitStatus, Weapon } from '../../src/types/index'
 import './App.css'
 
 const turnPhaseLabels: Record<TurnPhase, string> = {
@@ -109,23 +109,39 @@ function getActionableModes(status: UnitStatus | undefined, weapons: ReadonlyArr
   return hasReadyWeapon ? ['fire', 'combined'] : []
 }
 
-function buildLiveDefenders(authoritativeState: GameState, activeTurnActive: boolean): BattlefieldUnit[] {
+function buildLiveDefenders(snapshot: GameSnapshot, activePhase: TurnPhase | null, activeTurnActive: boolean): BattlefieldUnit[] {
+  const authoritativeState = snapshot.authoritativeState
+
+  if (authoritativeState === undefined) {
+    return []
+  }
+
+  const movementRemainingByUnit = snapshot.movementRemainingByUnit ?? {}
+
   return Object.entries(authoritativeState.defenders).map(([defenderId, defender]) => ({
     id: defender.id ?? defenderId,
     type: defender.type,
     status: defender.status,
     q: defender.position.q,
     r: defender.position.r,
-    move: 0,
+    move: activePhase === null ? 0 : movementRemainingByUnit[defender.id ?? defenderId] ?? 0,
     weapons: formatWeaponSummary(defender.weapons),
     attack: formatAttackSummary(defender.weapons),
     actionableModes: getActionableModes(defender.status, defender.weapons, activeTurnActive),
   }))
 }
 
-function buildLiveOnion(authoritativeState: GameState): BattlefieldOnionView {
+function buildLiveOnion(snapshot: GameSnapshot, activePhase: TurnPhase | null): BattlefieldOnionView {
+  const authoritativeState = snapshot.authoritativeState
+
+  if (authoritativeState === undefined) {
+    throw new Error('Missing authoritative state')
+  }
+
   const onion = authoritativeState.onion
-  const movesAllowed = onionMovementAllowance(onion.treads)
+  const movementRemainingByUnit = snapshot.movementRemainingByUnit ?? {}
+  const movesAllowed = activePhase === null ? 0 : getUnitMovementAllowance('TheOnion', activePhase, onion.treads)
+  const movesRemaining = activePhase === null ? 0 : movementRemainingByUnit[onion.id ?? 'onion-1'] ?? 0
 
   return {
     id: onion.id ?? 'onion-1',
@@ -135,7 +151,7 @@ function buildLiveOnion(authoritativeState: GameState): BattlefieldOnionView {
     status: onion.status ?? 'operational',
     treads: onion.treads,
     movesAllowed,
-    movesUsed: 0,
+    movesRemaining,
     rams: authoritativeState.ramsThisTurn ?? 0,
     weapons: formatWeaponSummary(onion.weapons),
   }
@@ -263,7 +279,7 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
   const isControlledSession = activeGameClient !== undefined && activeGameIdProp !== undefined
   const activePhase = clientSnapshot?.phase ?? null
   const activeMode = clientSnapshot?.mode ?? mode
-  const activeSelectedUnitId = clientSnapshot?.selectedUnitId ?? selectedUnitId
+  const activeSelectedUnitId = selectedUnitId !== '' ? selectedUnitId : (clientSnapshot?.selectedUnitId ?? '')
   const headerHasSnapshot = clientSnapshot !== null
   const activeTurnNumber = clientSnapshot?.turnNumber ?? null
   const activeScenarioName = clientSnapshot?.scenarioName ?? null
@@ -343,12 +359,13 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
   }
 
   function handleSelectUnit(unitId: string) {
-    if (isControlledSession) {
-      void commitClientAction({ type: 'select-unit', unitId })
-      return
-    }
-
     setSelectedUnitId(unitId)
+    setActionError(null)
+  }
+
+  function handleDeselectUnit() {
+    setSelectedUnitId('')
+    setActionError(null)
   }
 
   function handleModeChange(nextMode: Mode) {
@@ -360,15 +377,40 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
     setMode(nextMode)
   }
 
-  const authoritativeState = clientSnapshot?.authoritativeState
-  const displayedDefenders = authoritativeState === undefined ? [] : buildLiveDefenders(authoritativeState, activeTurnActive)
-  const displayedOnion = authoritativeState === undefined ? null : buildLiveOnion(authoritativeState)
+  async function handleMoveUnit(unitId: string, to: { q: number; r: number }) {
+    if (!isControlledSession || activeGameClient === undefined || activeGameIdProp === undefined) {
+      return
+    }
+
+    if (!activeTurnActive) {
+      return
+    }
+
+    setActionError(null)
+    snapshotLoadVersion.current += 1
+    try {
+      const nextSnapshot = await activeGameClient.submitAction(activeGameIdProp, { type: 'MOVE', unitId, to })
+      setClientSnapshot(nextSnapshot)
+      setSelectedUnitId('')
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof GameClientSeamError
+          ? `GameClientSeamError: ${error.message}`
+          : error instanceof Error && error.message
+            ? `Error: ${error.message}`
+            : 'Error unknown'
+      setActionError(`Failed to submit action: ${errorMessage}`)
+    }
+  }
+
+  const displayedDefenders = clientSnapshot === null ? [] : buildLiveDefenders(clientSnapshot, activePhase, activeTurnActive)
+  const displayedOnion = clientSnapshot === null ? null : buildLiveOnion(clientSnapshot, activePhase)
   const displayedScenarioMap = buildScenarioMap(clientSnapshot)
   const hasBattlefieldData = displayedOnion !== null && displayedScenarioMap !== null
   const yourTurn = true
   const isOnionSelected = displayedOnion !== null && activeSelectedUnitId === displayedOnion.id
   const selectedDefender = displayedDefenders.find((unit) => unit.id === activeSelectedUnitId)
-  const selectedUnit = selectedDefender ?? displayedDefenders[0]
+  const selectedUnit = selectedDefender ?? null
   const targetLabel = activeMode === 'end-phase' ? 'No target required' : 'onion / treads'
   const selectedUnitIsActionable = selectedUnit?.actionableModes.includes(activeMode) ?? false
   const onionWeapons = parseWeaponStats(displayedOnion?.weapons ?? '')
@@ -634,7 +676,7 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
                 <div className="unit-summary">
                   <div className="summary-line">
                     <span>Treads <strong>{displayedOnion.treads}</strong></span>
-                    <span>Moves <strong>{displayedOnion.movesAllowed - displayedOnion.movesUsed}</strong></span>
+                    <span>Moves <strong>{displayedOnion.movesRemaining}</strong></span>
                     <span>Rams <strong>{displayedOnion.rams}</strong></span>
                   </div>
                   <div className="summary-line">
@@ -697,9 +739,12 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
                 scenarioMap={displayedScenarioMap}
                 defenders={displayedDefenders}
                 onion={displayedOnion}
-                mode={activeMode}
+                phase={activePhase}
                 selectedUnitId={activeSelectedUnitId}
+                canSubmitMove={activeTurnActive}
                 onSelectUnit={handleSelectUnit}
+                onDeselect={handleDeselectUnit}
+                onMoveUnit={handleMoveUnit}
               />
             ) : (
               <div className="hex-map-shell panel-subtle">
@@ -787,7 +832,7 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
                   </div>
                   <div>
                     <dt>Move Available</dt>
-                    <dd>{displayedOnion.movesAllowed - displayedOnion.movesUsed} / {displayedOnion.movesAllowed}</dd>
+                    <dd>{displayedOnion.movesRemaining} / {displayedOnion.movesAllowed}</dd>
                   </div>
                   <div>
                     <dt>Rams</dt>

--- a/web/src/components/HexMapBoard.css
+++ b/web/src/components/HexMapBoard.css
@@ -45,8 +45,33 @@
   stroke-width: 2;
 }
 
+.hex-cell-move-ready > .hex-shape {
+  stroke: #2e7d32;
+  stroke-width: 2;
+}
+
+.hex-cell-reachable > .hex-shape {
+  fill: rgba(102, 187, 106, 0.22);
+  stroke: #66bb6a;
+  stroke-width: 2;
+}
+
 .hex-shape {
   pointer-events: auto;
+}
+
+.hex-unit-stack {
+  cursor: pointer;
+  pointer-events: all;
+}
+
+.hex-unit-stack-selected .hex-unit-rect {
+  stroke: #ffeb3b;
+  stroke-width: 3;
+}
+
+.hex-unit-stack-move-ready .hex-unit-rect {
+  filter: saturate(1.15);
 }
 
 /* Unit rectangle - defender (red) */
@@ -64,10 +89,27 @@
 }
 
 /* Unit rectangle - actionable state (green tint) */
-.hex-unit-rect-actionable {
+.hex-unit-rect-move-ready {
   fill: #66bb6a;
   stroke: #2e7d32;
   stroke-width: 2.5;
+}
+
+.hex-unit-rect-selected {
+  stroke: #ffeb3b;
+  stroke-width: 3;
+}
+
+.hex-map-toast {
+  position: fixed;
+  z-index: 20;
+  padding: 8px 12px;
+  background: rgba(24, 39, 35, 0.95);
+  color: #f8fff8;
+  border: 1px solid rgba(102, 187, 106, 0.55);
+  border-radius: 999px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  pointer-events: auto;
 }
 
 .hex-unit-marker {

--- a/web/src/components/HexMapBoard.test.tsx
+++ b/web/src/components/HexMapBoard.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { HexMapBoard } from './HexMapBoard'
+import type { BattlefieldOnionView, BattlefieldUnit, TerrainHex } from '../lib/battlefieldView'
+
+const scenarioMap = {
+	width: 5,
+	height: 5,
+	hexes: [] as TerrainHex[],
+}
+
+const onion: BattlefieldOnionView = {
+	id: 'onion-1',
+	type: 'TheOnion',
+	q: 0,
+	r: 0,
+	status: 'operational',
+	treads: 33,
+	movesAllowed: 3,
+	movesRemaining: 3,
+	rams: 0,
+	weapons: 'main: ready',
+}
+
+const defenders: BattlefieldUnit[] = [
+	{
+		id: 'puss-1',
+		type: 'Puss',
+		status: 'operational',
+		q: 1,
+		r: 1,
+		move: 3,
+		weapons: 'main: ready',
+		attack: '4 / rng 2',
+		actionableModes: ['fire', 'combined'],
+	},
+	{
+		id: 'wolf-2',
+		type: 'BigBadWolf',
+		status: 'operational',
+		q: 2,
+		r: 2,
+		move: 4,
+		weapons: 'main: ready',
+		attack: '2 / rng 2',
+		actionableModes: ['fire', 'combined'],
+	},
+]
+
+describe('HexMapBoard', () => {
+	it('highlights an eligible selected unit and its reachable move radius', () => {
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={defenders}
+				onion={onion}
+				phase="DEFENDER_MOVE"
+				selectedUnitId="puss-1"
+				onSelectUnit={vi.fn()}
+				onDeselect={vi.fn()}
+				onMoveUnit={vi.fn()}
+			/>,
+		)
+
+		const selectedCell = screen.getByTestId('hex-cell-1-1')
+		const reachableCell = screen.getByTestId('hex-cell-2-1')
+		expect(selectedCell?.getAttribute('class')).toContain('hex-cell-selected')
+		expect(selectedCell?.getAttribute('class')).toContain('hex-cell-move-ready')
+		expect(reachableCell?.getAttribute('class')).toContain('hex-cell-reachable')
+	})
+
+	it('deselects when the user left-clicks an empty hex', () => {
+		const onDeselect = vi.fn()
+
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={defenders}
+				onion={onion}
+				phase="DEFENDER_MOVE"
+				selectedUnitId="puss-1"
+				onSelectUnit={vi.fn()}
+				onDeselect={onDeselect}
+				onMoveUnit={vi.fn()}
+			/>,
+		)
+
+		fireEvent.click(screen.getByTestId('hex-cell-2-0'))
+		expect(onDeselect).toHaveBeenCalledTimes(1)
+	})
+
+	it('submits a move when the user right-clicks an in-range hex', () => {
+		const onMoveUnit = vi.fn()
+
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={defenders}
+				onion={onion}
+				phase="DEFENDER_MOVE"
+				selectedUnitId="puss-1"
+				onSelectUnit={vi.fn()}
+				onDeselect={vi.fn()}
+				onMoveUnit={onMoveUnit}
+			/>,
+		)
+
+		fireEvent.contextMenu(screen.getByTestId('hex-cell-2-1'))
+		expect(onMoveUnit).toHaveBeenCalledWith('puss-1', { q: 2, r: 1 })
+	})
+
+	it('renders and selects both occupants when the onion and a defender share a hex', () => {
+		const onSelectUnit = vi.fn()
+		const sharedOnion: BattlefieldOnionView = {
+			...onion,
+			q: 1,
+			r: 1,
+		}
+		const sharedDefender: BattlefieldUnit = {
+			...defenders[0],
+			q: 1,
+			r: 1,
+		}
+
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={[sharedDefender]}
+				onion={sharedOnion}
+				phase="ONION_MOVE"
+				selectedUnitId="onion-1"
+				onSelectUnit={onSelectUnit}
+				onDeselect={vi.fn()}
+				onMoveUnit={vi.fn()}
+			/>,
+		)
+
+		expect(screen.getByTestId('hex-unit-onion-1')).not.toBeNull()
+		expect(screen.getByTestId('hex-unit-puss-1')).not.toBeNull()
+
+		fireEvent.click(screen.getByTestId('hex-unit-puss-1'))
+		expect(onSelectUnit).toHaveBeenCalledWith('puss-1')
+
+		fireEvent.click(screen.getByTestId('hex-unit-onion-1'))
+		expect(onSelectUnit).toHaveBeenCalledWith('onion-1')
+	})
+
+	it('ignores right-clicks when the selected unit is invalid', () => {
+		const onMoveUnit = vi.fn()
+
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={defenders}
+				onion={onion}
+				phase="DEFENDER_MOVE"
+				selectedUnitId="ghost-unit"
+				onSelectUnit={vi.fn()}
+				onDeselect={vi.fn()}
+				onMoveUnit={onMoveUnit}
+			/>,
+		)
+
+		fireEvent.contextMenu(screen.getByTestId('hex-cell-2-1'))
+		expect(onMoveUnit).not.toHaveBeenCalled()
+		expect(screen.queryByText(/illegal move/i)).toBeNull()
+	})
+
+	it('ignores right-clicks when move submission is disabled', () => {
+		const onMoveUnit = vi.fn()
+
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={defenders}
+				onion={onion}
+				phase="DEFENDER_MOVE"
+				selectedUnitId="puss-1"
+				canSubmitMove={false}
+				onSelectUnit={vi.fn()}
+				onDeselect={vi.fn()}
+				onMoveUnit={onMoveUnit}
+			/>,
+		)
+
+		fireEvent.contextMenu(screen.getByTestId('hex-cell-2-1'))
+		expect(onMoveUnit).not.toHaveBeenCalled()
+		expect(screen.queryByText(/illegal move/i)).toBeNull()
+	})
+
+	it('shows an out-of-range bubble when the user right-clicks an invalid hex', () => {
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={defenders}
+				onion={onion}
+				phase="DEFENDER_MOVE"
+				selectedUnitId="onion-1"
+				onSelectUnit={vi.fn()}
+				onDeselect={vi.fn()}
+				onMoveUnit={vi.fn()}
+			/>,
+		)
+
+		fireEvent.contextMenu(screen.getByTestId('hex-cell-4-4'))
+		expect(screen.getByText(/illegal move/i)).not.toBeNull()
+	})
+})

--- a/web/src/components/HexMapBoard.tsx
+++ b/web/src/components/HexMapBoard.tsx
@@ -1,6 +1,11 @@
+import { useEffect, useMemo, useState } from 'react'
 import { axialToPixel, boardPixelSize, hexCorners, hexKey, pointsToString } from '../lib/hex'
-import { unitCode, type BattlefieldOnionView, type BattlefieldUnit, type Mode, type TerrainHex } from '../lib/battlefieldView'
+import { unitCode, type BattlefieldOnionView, type BattlefieldUnit, type TerrainHex } from '../lib/battlefieldView'
+import { canUnitCrossRidgelines } from '../../../src/shared/unitMovement'
+import { listReachableMoves } from '../../../src/shared/movePlanner'
 import './HexMapBoard.css'
+
+type HexOccupant = BattlefieldUnit | BattlefieldOnionView
 
 type HexMapBoardProps = {
   scenarioMap: {
@@ -10,28 +15,108 @@ type HexMapBoardProps = {
   }
   defenders: BattlefieldUnit[]
   onion: BattlefieldOnionView
-  mode: Mode
+  phase: string | null
   selectedUnitId: string
+  canSubmitMove?: boolean
   onSelectUnit: (unitId: string) => void
+  onDeselect: () => void
+  onMoveUnit: (unitId: string, to: { q: number; r: number }) => void
 }
 
 const HEX_SIZE = 36
 const MAP_PADDING = 28
 
-export function HexMapBoard({ scenarioMap, defenders, onion, mode, selectedUnitId, onSelectUnit }: HexMapBoardProps) {
-  const terrain = new Map(scenarioMap.hexes.map((hex) => [hexKey(hex), hex.t]))
-  const occupantMap = new Map<string, BattlefieldUnit | BattlefieldOnionView>()
+function getStackOffset(index: number, total: number): { dx: number; dy: number } {
+  if (total <= 1) {
+    return { dx: 0, dy: 0 }
+  }
 
-  occupantMap.set(hexKey(onion), onion)
+  if (total === 2) {
+    return { dx: 0, dy: index === 0 ? -11 : 11 }
+  }
+
+  const radius = 11
+  const angle = (Math.PI * 2 * index) / total - Math.PI / 2
+  return {
+    dx: Math.round(Math.cos(angle) * radius),
+    dy: Math.round(Math.sin(angle) * radius),
+  }
+}
+
+export function HexMapBoard({ scenarioMap, defenders, onion, phase, selectedUnitId, canSubmitMove = true, onSelectUnit, onDeselect, onMoveUnit }: HexMapBoardProps) {
+  const terrain = new Map(scenarioMap.hexes.map((hex) => [hexKey(hex), hex.t]))
+  const occupantMap = new Map<string, HexOccupant[]>()
+  const [moveError, setMoveError] = useState<{ message: string; x: number; y: number } | null>(null)
+
+  occupantMap.set(hexKey(onion), [onion])
   for (const defender of defenders) {
     if (defender.status === 'destroyed') continue
-    occupantMap.set(hexKey(defender), defender)
+    const key = hexKey(defender)
+    const occupants = occupantMap.get(key) ?? []
+    occupants.push(defender)
+    occupantMap.set(key, occupants)
   }
+
+  const selectedOccupant =
+    selectedUnitId === onion.id
+      ? onion
+      : defenders.find((unit) => unit.id === selectedUnitId) ?? null
+  const selectedAllowance = selectedOccupant
+    ? selectedOccupant.id === onion.id
+      ? onion.movesRemaining
+      : 'move' in selectedOccupant
+        ? selectedOccupant.move
+        : 0
+    : 0
+  const selectedCanCrossRidgelines = selectedOccupant ? canUnitCrossRidgelines(selectedOccupant.type) : false
+  const occupiedHexes = Array.from(occupantMap.entries())
+    .flatMap(([key, occupants]) => {
+      const [q, r] = key.split(',').map(Number)
+      return occupants
+        .filter((occupant) => occupant.id !== selectedUnitId && occupant.status !== 'destroyed')
+        .map((occupant) => ({
+          q,
+          r,
+          role: occupant.id === onion.id ? ('onion' as const) : ('defender' as const),
+          unitType: occupant.type,
+        }))
+    })
+  const isMovementPhase = phase === 'ONION_MOVE' || phase === 'DEFENDER_MOVE' || phase === 'GEV_SECOND_MOVE'
+  const reachableMoves =
+    isMovementPhase && selectedOccupant && selectedAllowance > 0
+      ? listReachableMoves({
+          map: { ...scenarioMap, occupiedHexes },
+          from: { q: selectedOccupant.q, r: selectedOccupant.r },
+          movementAllowance: selectedAllowance,
+          canCrossRidgelines: selectedCanCrossRidgelines,
+          movingRole: selectedOccupant.id === onion.id ? 'onion' : 'defender',
+          movingUnitType: selectedOccupant.type,
+        })
+      : []
+  const reachableHexKeys = useMemo(() => new Set(reachableMoves.map((move) => hexKey(move.to))), [reachableMoves])
+
+  useEffect(() => {
+    if (!moveError) return undefined
+
+    const timeoutId = window.setTimeout(() => setMoveError(null), 3000)
+    const dismiss = () => setMoveError(null)
+    window.addEventListener('click', dismiss, true)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+      window.removeEventListener('click', dismiss, true)
+    }
+  }, [moveError])
 
   const bounds = boardPixelSize(scenarioMap.width, scenarioMap.height, HEX_SIZE, MAP_PADDING)
 
   return (
     <div className="hex-map-shell panel-subtle">
+      {moveError ? (
+        <div className="hex-map-toast" style={{ left: moveError.x + 12, top: moveError.y + 12 }} role="status">
+          {moveError.message}
+        </div>
+      ) : null}
       <svg
         className="hex-map-svg"
         width={bounds.width}
@@ -47,16 +132,16 @@ export function HexMapBoard({ scenarioMap, defenders, onion, mode, selectedUnitI
               const center = axialToPixel(coord, HEX_SIZE)
               const polygonPoints = pointsToString(hexCorners(center, HEX_SIZE - 1))
               const terrainType = terrain.get(hexKey(coord))
-              const occupant = occupantMap.get(hexKey(coord))
-              const isOnion = occupant?.id === onion.id
-              const isSelected = occupant?.id === selectedUnitId
-              const isActionable = Boolean(
-                occupant &&
-                  occupant.id !== onion.id &&
-                  'actionableModes' in occupant &&
-                  occupant.actionableModes.includes(mode),
+              const cellOccupants = occupantMap.get(hexKey(coord)) ?? []
+              const isOnion = cellOccupants.some((occupant) => occupant.id === onion.id)
+              const isSelected = cellOccupants.some((occupant) => occupant.id === selectedUnitId)
+              const isMoveReady = cellOccupants.some(
+                (occupant) =>
+                  isMovementPhase &&
+                  occupant.status === 'operational' &&
+                  ((occupant.id === onion.id ? onion.movesRemaining : 'move' in occupant ? occupant.move : 0) > 0),
               )
-              const unitMarker = occupant ? unitCode(occupant.type) : null
+              const isReachable = reachableHexKeys.has(hexKey(coord))
 
 
               // Pick SVG image for terrain
@@ -70,18 +155,38 @@ export function HexMapBoard({ scenarioMap, defenders, onion, mode, selectedUnitI
               return (
                 <g
                   key={`${q}-${r}`}
+                  data-testid={`hex-cell-${q}-${r}`}
                   className={[
                     'hex-cell',
                     terrainType ? `hex-terrain-${terrainType}` : 'hex-terrain-default',
                     isSelected ? 'hex-cell-selected' : '',
-                    isActionable ? 'hex-cell-actionable' : '',
+                    isMoveReady ? 'hex-cell-move-ready' : '',
+                    isReachable ? 'hex-cell-reachable' : '',
                     isOnion ? 'hex-cell-onion' : '',
-                    occupant ? 'hex-cell-occupied' : '',
+                    cellOccupants.length > 0 ? 'hex-cell-occupied' : '',
                   ].join(' ')}
                   onClick={() => {
-                    if (occupant && occupant.id !== onion.id && 'actionableModes' in occupant) {
-                      onSelectUnit(occupant.id)
+                    if (cellOccupants.length === 0) {
+                      onDeselect()
+                      return
                     }
+
+                    if (cellOccupants.length === 1) {
+                      onSelectUnit(cellOccupants[0].id)
+                    }
+                  }}
+                  onContextMenu={(event) => {
+                    event.preventDefault()
+                    if (!selectedOccupant || !canSubmitMove) {
+                      return
+                    }
+
+                    if (isReachable) {
+                      onMoveUnit(selectedOccupant.id, coord)
+                      return
+                    }
+
+                    setMoveError({ message: 'Illegal move', x: event.clientX, y: event.clientY })
                   }}
                 >
                   <clipPath id={`hex-clip-${q}-${r}`}><polygon points={polygonPoints} /></clipPath>
@@ -95,25 +200,47 @@ export function HexMapBoard({ scenarioMap, defenders, onion, mode, selectedUnitI
                     preserveAspectRatio="xMidYMid slice"
                   />
                   <polygon className="hex-shape" points={polygonPoints} fill="none" />
-                  {occupant ? (
-                    <>
-                      <rect
+                  {cellOccupants.map((occupant, index) => {
+                    const isOccupantOnion = occupant.id === onion.id
+                    const isOccupantSelected = occupant.id === selectedUnitId
+                    const offset = getStackOffset(index, cellOccupants.length)
+                    const moveRemaining = isOccupantOnion ? onion.movesRemaining : 'move' in occupant ? occupant.move : 0
+
+                    return (
+                      <g
+                        key={occupant.id}
+                        data-testid={`hex-unit-${occupant.id}`}
                         className={[
-                          'hex-unit-rect',
-                          isOnion ? 'hex-unit-rect-onion' : 'hex-unit-rect-defender',
-                          isActionable ? 'hex-unit-rect-actionable' : '',
+                          'hex-unit-stack',
+                          isOccupantOnion ? 'hex-unit-stack-onion' : 'hex-unit-stack-defender',
+                          isOccupantSelected ? 'hex-unit-stack-selected' : '',
+                          isMovementPhase && occupant.status === 'operational' && moveRemaining > 0 ? 'hex-unit-stack-move-ready' : '',
                         ].join(' ')}
-                        x={center.x - 16}
-                        y={center.y - 11}
-                        width={32}
-                        height={22}
-                        rx={2}
-                      />
-                      <text className="hex-unit-marker" x={center.x} y={center.y + 4} textAnchor="middle">
-                        {unitMarker}
-                      </text>
-                    </>
-                  ) : null}
+                        transform={`translate(${offset.dx}, ${offset.dy})`}
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          onSelectUnit(occupant.id)
+                        }}
+                      >
+                        <rect
+                          className={[
+                            'hex-unit-rect',
+                            isOccupantOnion ? 'hex-unit-rect-onion' : 'hex-unit-rect-defender',
+                            isOccupantSelected ? 'hex-unit-rect-selected' : '',
+                            isMovementPhase && occupant.status === 'operational' && moveRemaining > 0 ? 'hex-unit-rect-move-ready' : '',
+                          ].join(' ')}
+                          x={center.x - 16}
+                          y={center.y - 11}
+                          width={32}
+                          height={22}
+                          rx={2}
+                        />
+                        <text className="hex-unit-marker" x={center.x} y={center.y + 4} textAnchor="middle">
+                          {unitCode(occupant.type)}
+                        </text>
+                      </g>
+                    )
+                  })}
                   <text className="hex-coord" x={center.x} y={center.y + 18} textAnchor="middle">
                     {q},{r}
                   </text>

--- a/web/src/lib/battlefieldView.ts
+++ b/web/src/lib/battlefieldView.ts
@@ -21,7 +21,7 @@ export type BattlefieldOnionView = {
   status: string
   treads: number
   movesAllowed: number
-  movesUsed: number
+  movesRemaining: number
   rams: number
   weapons: string
 }

--- a/web/src/lib/gameClient.ts
+++ b/web/src/lib/gameClient.ts
@@ -19,6 +19,7 @@ export type GameSnapshot = {
 	turnNumber?: number
 	lastEventSeq: number
 	authoritativeState?: GameState
+	movementRemainingByUnit?: Record<string, number>
 	scenarioMap?: ScenarioMapSnapshot
 }
 
@@ -34,6 +35,7 @@ export type GameStateEnvelope = {
 export type GameAction =
 	| { type: 'select-unit'; unitId: string }
 	| { type: 'set-mode'; mode: ActionMode }
+	| { type: 'MOVE'; unitId: string; to: { q: number; r: number } }
 	| { type: 'end-phase' }
 	| { type: 'refresh' }
 

--- a/web/src/lib/httpGameClient.adapter.contract.test.ts
+++ b/web/src/lib/httpGameClient.adapter.contract.test.ts
@@ -30,6 +30,10 @@ describe('http game client adapter contract', () => {
 						},
 					},
 				},
+				movementRemainingByUnit: {
+					'onion-1': 0,
+					'wolf-2': 0,
+				},
 				scenarioMap: {
 					width: 15,
 					height: 22,
@@ -63,6 +67,10 @@ describe('http game client adapter contract', () => {
 						},
 					},
 				},
+					movementRemainingByUnit: {
+						'onion-1': 0,
+						'wolf-2': 0,
+					},
 				gameId: 123,
 				phase: 'DEFENDER_COMBAT',
 				selectedUnitId: null,
@@ -119,6 +127,9 @@ describe('http game client adapter contract', () => {
 				scenarioName: "The Siege of Shrek's Swamp",
 				turnNumber: 8,
 				state: { onion: { position: { q: 0, r: 0 }, treads: 45 }, defenders: {} },
+					movementRemainingByUnit: {
+						'onion-1': 0,
+					},
 				eventSeq: 47,
 			}))
 			.mockResolvedValueOnce(jsonResponse({
@@ -128,6 +139,9 @@ describe('http game client adapter contract', () => {
 				scenarioName: "The Siege of Shrek's Swamp",
 				turnNumber: 8,
 				state: { onion: { position: { q: 0, r: 1 }, treads: 43 }, defenders: {} },
+					movementRemainingByUnit: {
+						'onion-1': 0,
+					},
 				eventSeq: 49,
 			}))
 
@@ -142,6 +156,7 @@ describe('http game client adapter contract', () => {
 
 		await expect(client.submitAction(123, { type: 'refresh' })).resolves.toEqual({
 			authoritativeState: { onion: { position: { q: 0, r: 1 }, treads: 43 }, defenders: {} },
+			movementRemainingByUnit: { 'onion-1': 0 },
 			gameId: 123,
 			phase: 'DEFENDER_COMBAT',
 			selectedUnitId: 'wolf-2',
@@ -170,6 +185,7 @@ describe('http game client adapter contract', () => {
 				scenarioName: "The Siege of Shrek's Swamp",
 				turnNumber: 2,
 				state: { onion: { position: { q: 0, r: 0 }, treads: 45 }, defenders: {} },
+				movementRemainingByUnit: { 'onion-1': 3 },
 				eventSeq: 12,
 			}))
 			.mockResolvedValueOnce(jsonResponse({
@@ -179,6 +195,7 @@ describe('http game client adapter contract', () => {
 					{ seq: 13, type: 'PHASE_CHANGED', timestamp: '2026-03-26T12:00:00.000Z', from: 'ONION_MOVE', to: 'ONION_COMBAT', turnNumber: 2 },
 				],
 				state: { onion: { position: { q: 0, r: 0 }, treads: 45 }, defenders: {} },
+				movementRemainingByUnit: { 'onion-1': 0 },
 				turnNumber: 2,
 				eventSeq: 13,
 			}))
@@ -192,6 +209,7 @@ describe('http game client adapter contract', () => {
 		await client.getState(123)
 		await expect(client.submitAction(123, { type: 'end-phase' })).resolves.toEqual({
 			authoritativeState: { onion: { position: { q: 0, r: 0 }, treads: 45 }, defenders: {} },
+			movementRemainingByUnit: { 'onion-1': 0 },
 			gameId: 123,
 			phase: 'ONION_COMBAT',
 			selectedUnitId: null,
@@ -211,6 +229,66 @@ describe('http game client adapter contract', () => {
 					'content-type': 'application/json',
 				}),
 				body: JSON.stringify({ type: 'END_PHASE' }),
+			}),
+		)
+	})
+
+	it('sends MOVE actions to the backend actions endpoint', async () => {
+		const jsonResponse = (body: unknown, status = 200) => ({
+			ok: true,
+			status,
+			text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+		})
+
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({
+				gameId: 123,
+				role: 'defender',
+				phase: 'DEFENDER_MOVE',
+				scenarioName: "The Siege of Shrek's Swamp",
+				turnNumber: 8,
+				state: { onion: { position: { q: 0, r: 0 }, treads: 45 }, defenders: {} },
+				movementRemainingByUnit: { 'wolf-2': 4 },
+				eventSeq: 47,
+			}))
+			.mockResolvedValueOnce(jsonResponse({
+				ok: true,
+				seq: 48,
+				events: [
+					{ seq: 48, type: 'UNIT_MOVED', timestamp: '2026-03-26T12:00:00.000Z', unitId: 'wolf-2', to: { q: 7, r: 6 } },
+				],
+				state: { onion: { position: { q: 0, r: 0 }, treads: 45 }, defenders: {} },
+				movementRemainingByUnit: { 'wolf-2': 3 },
+				turnNumber: 8,
+				eventSeq: 48,
+			}))
+
+		const client = createHttpGameClient({
+			baseUrl: 'https://onion.test/api',
+			fetchImpl,
+			token: 'stub.token',
+		})
+
+		await client.getState(123)
+		await expect(client.submitAction(123, { type: 'MOVE', unitId: 'wolf-2', to: { q: 7, r: 6 } })).resolves.toEqual(
+			expect.objectContaining({
+				gameId: 123,
+				phase: 'DEFENDER_MOVE',
+				lastEventSeq: 48,
+				movementRemainingByUnit: { 'wolf-2': 3 },
+			}),
+		)
+
+		expect(fetchImpl.mock.calls[1]?.[0]).toBe('https://onion.test/api/games/123/actions')
+		expect(fetchImpl.mock.calls[1]?.[1]).toEqual(
+			expect.objectContaining({
+				method: 'POST',
+				headers: expect.objectContaining({
+					authorization: 'Bearer stub.token',
+					'content-type': 'application/json',
+				}),
+				body: JSON.stringify({ type: 'MOVE', unitId: 'wolf-2', to: { q: 7, r: 6 } }),
 			}),
 		)
 	})

--- a/web/src/lib/httpGameClient.ts
+++ b/web/src/lib/httpGameClient.ts
@@ -17,6 +17,7 @@ type ActionSuccessResponse = {
 	seq: number
 	events: Array<{ seq: number; type: string; timestamp: string; [key: string]: unknown }>
 	state: GameState
+	movementRemainingByUnit: Record<string, number>
 	turnNumber: number
 	eventSeq: number
 }
@@ -58,6 +59,7 @@ function createInitialSnapshot(gameId: number): GameSnapshot {
 		scenarioName: undefined,
 		turnNumber: undefined,
 		lastEventSeq: 0,
+		movementRemainingByUnit: {},
 	}
 }
 
@@ -94,6 +96,7 @@ function mapServerSnapshot(
 			turnNumber: typeof response.turnNumber === 'number' ? response.turnNumber : fallback.turnNumber,
 			lastEventSeq: typeof response.eventSeq === 'number' ? response.eventSeq : fallback.lastEventSeq,
 			authoritativeState: response.state ?? fallback.authoritativeState,
+			movementRemainingByUnit: response.movementRemainingByUnit ?? fallback.movementRemainingByUnit,
 			scenarioMap: response.scenarioMap ?? fallback.scenarioMap,
 		}),
 		session: {
@@ -117,6 +120,7 @@ function mapActionSnapshot(
 		turnNumber: typeof response.turnNumber === 'number' ? response.turnNumber : fallback.turnNumber,
 		lastEventSeq: typeof response.eventSeq === 'number' ? response.eventSeq : typeof response.seq === 'number' ? response.seq : fallback.lastEventSeq,
 		authoritativeState: response.state ?? fallback.authoritativeState,
+		movementRemainingByUnit: response.movementRemainingByUnit ?? fallback.movementRemainingByUnit,
 	})
 }
 
@@ -165,6 +169,28 @@ export function createHttpGameClient(options: HttpGameClientOptions): GameClient
 					method: 'POST',
 					token: options.token,
 					body: { type: 'END_PHASE' },
+					fetchImpl,
+				})
+
+				if (!result.ok) {
+					throw buildError(result)
+				}
+
+				currentSnapshot = mapActionSnapshot(result.data, currentSnapshot, gameId)
+				return currentSnapshot
+			}
+
+			if (action.type === 'MOVE') {
+				const result = await requestJson<ActionSuccessResponse>({
+					baseUrl,
+					path: `games/${gameId}/actions`,
+					method: 'POST',
+					token: options.token,
+					body: {
+						type: 'MOVE',
+						unitId: action.unitId,
+						to: action.to,
+					},
 					fetchImpl,
 				})
 

--- a/web/src/mockBattlefield.ts
+++ b/web/src/mockBattlefield.ts
@@ -1,4 +1,4 @@
-import type { BattlefieldUnit, Mode, TerrainHex, TimelineEvent } from './lib/battlefieldView'
+import type { Mode, TimelineEvent } from './lib/battlefieldView'
 
 export const battlefieldModes: Array<{ id: Mode; label: string; helper: string }> = [
   { id: 'fire', label: 'Fire Unit', helper: 'Pick one attacker and one target.' },


### PR DESCRIPTION
## Summary

Wired movement to Web UI. Movement mechanic specced in docs/web-ui-spec.md.

Work included a refactor of movement pathfinding into a shared component for consistency across layers. Pathfinding leveraged by UI to indicate available hexes per unit. 

Additional adds for discovered shared hex after ram situation:
- Board now renders all units in a shared hex as a stack, each independently selectable
- Added CSS for stacked unit clarity and selection
- Added regression test for shared-hex rendering/selection
- Fixed type errors and updated movement logic for new model
- All builds and tests green; manual and automated tests pass

## Context
This PR implements the entire movement mechanic into the UI. 