### PR TITLE
Wire Combat into the UI (AP targeting rules, docs, tests)

### DIFF
--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -39,6 +39,16 @@ Units are themed with Shrek-inspired names. Stats are listed as Attack/Range, De
   - **Tread Calculation**: Mk III starts with **45 Tread Points**.
     - 31-45 Treads: **MA 3** | 16-30 Treads: **MA 2** | 1-15 Treads: **MA 1** | 0 Treads: **MA 0**
 
+### Targeting Rules
+
+Target eligibility is data-driven and should be defined on the weapon or unit that owns the restriction. The engine and UI must use the same target-rule data when building legal target lists.
+
+- Weapon target rules live on the weapon definition when a specific weapon can only attack certain unit types or subsystems.
+- Unit target rules live on the unit definition when a unit can only be attacked by certain weapon types or weapon-defined target classes.
+- Target rules should use explicit unit and weapon identifiers, not abstract combat classes, so special cases remain easy to read and extend.
+- Scenario files do not author target rules directly; they reference unit types and the engine populates weapon and target-rule data from the shared unit definitions.
+- For the current Onion AP weapons, the source of truth is the Onion unit definition: AP weapons may target only Little Pigs and the Castle.
+
 ## Core Mechanics
 
 ### 1. Hexagonal Grid & Movement

--- a/docs/scenario-schema.md
+++ b/docs/scenario-schema.md
@@ -79,11 +79,19 @@ We use an **Axial Coordinate System** (q, r) where:
 }
 ```
 
-## 3. Map Encoding Convention
+## 3. Unit and Weapon Population
+
+Scenario JSON only declares the starting unit types, positions, and stack sizes. The engine populates the full weapon lists, weapon stats, and any target-rule metadata from the shared unit definitions at normalization time.
+
+1. Do not put combat target restrictions directly in scenario JSON.
+2. If a weapon or unit has special targeting restrictions, define them on the shared unit definition in the engine source of truth.
+3. Scenario `initialState` should remain focused on initial placement, stack sizes, and status fields that vary per scenario.
+
+## 4. Map Encoding Convention
 
 Only non-clear hexes need to appear in the `hexes` array. Any hex coordinate not listed is assumed to be terrain type `0` (Clear). This keeps scenario files compact.
 
-## 4. Unit Status State Machine
+## 5. Unit Status State Machine
 
 Defender units cycle through three states. The engine is responsible for advancing state automatically at the start of each Defender turn.
 
@@ -91,7 +99,7 @@ Defender units cycle through three states. The engine is responsible for advanci
 - `disabled`: Unit was hit with a "D" result this turn. It cannot move or fire. At the start of the **next** Defender turn, the engine transitions it to `recovering`.
 - `recovering`: Unit was disabled last turn. It returns to `operational` at the **start of the Recovery Phase** this turn and may act normally.
 
-## 5. Zod Implementation Notes
+## 6. Zod Implementation Notes
 
 We will define the following TS interfaces:
 
@@ -122,3 +130,5 @@ const UnitSchema = z.object({
   squads: z.number().optional() // For Little Pigs stacks only
 });
 ```
+
+The runtime unit definitions, not the scenario schema, supply the full weapon list and any weapon/unit target rules used by combat selection.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -11,6 +11,7 @@ break down into features/tasks as needed.
 - [ ] JWT authentication (migrate to @fastify/jwt)
 - [ ] Game lobby for creation and joining (self-service matchmaking)
 - [ ] Stacked unit management: UI and logic for selecting, splitting, and combining units in a stack; support for independent and combined moves and combat actions
+- [ ] Externalize unit and weapon definitions so types, stats, and target rules can move to a shared data file or schema later
 
 ## Features / Work Items
 
@@ -18,7 +19,6 @@ break down into features/tasks as needed.
 - [ ] Refactor movement resolution to read per-unit terrain rules from the shared unit definitions instead of hardcoded terrain checks.
   - [ ] Collapse the current split between movement profiles, pathfinding, and stacking rules so terrain entry, cover, and occupancy checks all come from the same unit/terrain definition model.
 - [ ] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
-- [ ] Unify combat math in a shared calculator used by both engine and web UI, including odds ratio and future terrain/stacking modifiers. This is shared rules logic only; base defense remains owned by the unit/weapon model and is out of scope.
 - [x] Audit defense source of truth for units and weapons so defense is defined once in the unit/weapon model and only derived for effective combat situations.
 - [x] Reuse the left-rail step badge area to show the selected group's combined attack value while units are selected or deselected.
 - [x] Combat phase one: attacker selection, targeting, and result presentation.

--- a/docs/web-ui-spec.md
+++ b/docs/web-ui-spec.md
@@ -265,14 +265,18 @@ unit roster, unit positions, or unit status once authoritative game data has loa
 - Selecting any attacker (or group) displays a range overlay on the map, similar to movement, but with an orange tint.
 - The range overlay must be computed in the web board model described above so it matches the rendered hex geometry.
 - For groups, the highlighted area is the intersection of all selected attackers’ ranges—only hexes all can reach are shown.
+- The attacker selector must also enforce weapon and unit targeting rules before showing a target as selectable.
+- The UI target list should only include targets allowed by the selected weapon(s) and by the target unit’s own restriction metadata, after range filtering is applied.
+- For the current AP rule, the selector must offer AP targets only for Little Pigs and the Castle.
 
 **Step 2: Target Confirmation**
 
-- Right-clicking an eligible target hex (within the highlighted range) opens a confirmation popup.
+- Right-clicking an eligible target hex or target list item (within the highlighted range and allowed by target rules) opens a confirmation popup.
 - The popup displays:
   - Attack:Defense ratio
   - All relevant combat modifiers and stats (e.g., terrain, stacking, special abilities)
   - Acknowledge/confirm button to commit the attack
+- If no legal target remains after applying weapon/unit target rules, the UI must show a clear empty-state message rather than offering an illegal target.
 
 **Step 3: Combat Results**
 

--- a/src/engine/combat.test.ts
+++ b/src/engine/combat.test.ts
@@ -422,6 +422,56 @@ describe('validateOnionWeaponFire', () => {
     const result = validateOnionWeaponFire(CLEAR_MAP, state, { type: 'FIRE', attackers: ['main'], targetId: 'd1' })
     expect(result.valid).toBe(false)
   })
+
+  it('rejects AP fire against non-infantry targets', () => {
+    const apWeapon = makeWeapon({
+      id: 'ap_1',
+      attack: 1,
+      range: 1,
+      defense: 1,
+      individuallyTargetable: true,
+    })
+    const onion = makeOnion({ weapons: [apWeapon] })
+    const defender = makeDefender({ id: 'wolf-1', type: 'BigBadWolf', position: { q: 1, r: 0 } })
+    const state = makeState({ onion, defenders: { 'wolf-1': defender } })
+
+    const result = validateOnionWeaponFire(CLEAR_MAP, state, { type: 'FIRE', attackers: ['ap_1'], targetId: 'wolf-1' })
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/AP/i)
+  })
+
+  it('allows AP fire against infantry targets', () => {
+    const apWeapon = makeWeapon({
+      id: 'ap_1',
+      attack: 1,
+      range: 1,
+      defense: 1,
+      individuallyTargetable: true,
+    })
+    const onion = makeOnion({ weapons: [apWeapon] })
+    const infantry = makeDefender({ id: 'pigs-1', type: 'LittlePigs', position: { q: 1, r: 0 }, squads: 1 })
+    const state = makeState({ onion, defenders: { 'pigs-1': infantry } })
+
+    const result = validateOnionWeaponFire(CLEAR_MAP, state, { type: 'FIRE', attackers: ['ap_1'], targetId: 'pigs-1' })
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('rejects fire against a target unit that excludes the attacker type', () => {
+    const defender = makeDefender({
+      id: 'd1',
+      type: 'BigBadWolf',
+      position: { q: 1, r: 0 },
+      targetRules: { allowedAttackerUnitTypes: ['BigBadWolf'] },
+    })
+    const state = makeState({ defenders: { d1: defender } })
+
+    const result = validateOnionWeaponFire(CLEAR_MAP, state, { type: 'FIRE', attackers: ['main'], targetId: 'd1' })
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/cannot target|invalid target/i)
+  })
 })
 
 describe('validateCombatAction', () => {

--- a/src/engine/combat.ts
+++ b/src/engine/combat.ts
@@ -15,6 +15,7 @@ import {
   type CombatCalculatorInput,
   type CombatStaticRules,
 } from '../shared/combatCalculator.js'
+import { isTargetAllowedByRules, resolveUnitTargetRules, resolveWeaponTargetRules } from '../shared/targetRules.js'
 import { getReadyWeapons, getUnitDefense, getWeaponDefense, destroyWeapon } from './units.js'
 import { getAllUnitDefinitions } from './units.js'
 import type { GameUnit, OnionUnit, DefenderUnit, EngineGameState } from './units.js'
@@ -69,6 +70,7 @@ export type CombatValidationCode =
   | 'ATTACKER_NOT_OPERATIONAL'
   | 'NO_READY_WEAPONS'
   | 'NO_TARGET'
+  | 'INVALID_TARGET'
   | 'TARGET_OUT_OF_RANGE'
   | 'NO_ATTACKERS'
   | 'COMBINED_FIRE_TREAD_TARGET'
@@ -358,6 +360,45 @@ export function validateCombatAction(
       const attackerId = normalizedCommand.attackers[index]
       if (hexDistance(state.onion.position, target.position) > weapon.range) {
         return { ok: false, code: 'TARGET_OUT_OF_RANGE', error: `Attacker '${attackerId}' is out of range` }
+      }
+    }
+
+    const defenderDefinition = COMBAT_STATIC_RULES.unitDefinitions[target.type]
+    const targetAllowed = weapons.every((weapon) =>
+      isTargetAllowedByRules(
+        {
+          unitType: 'TheOnion',
+          weaponId: weapon.id,
+          targetRules: resolveWeaponTargetRules(COMBAT_STATIC_RULES.unitDefinitions.TheOnion, weapon.id, weapon.targetRules),
+        },
+        {
+          unitType: target.type,
+          targetRules: resolveUnitTargetRules(defenderDefinition, target.targetRules),
+        },
+      ),
+    )
+
+    if (!targetAllowed) {
+      const invalidWeapon = weapons.find((weapon) =>
+        !isTargetAllowedByRules(
+          {
+            unitType: 'TheOnion',
+            weaponId: weapon.id,
+            targetRules: resolveWeaponTargetRules(COMBAT_STATIC_RULES.unitDefinitions.TheOnion, weapon.id, weapon.targetRules),
+          },
+          {
+            unitType: target.type,
+            targetRules: resolveUnitTargetRules(defenderDefinition, target.targetRules),
+          },
+        ),
+      )
+
+      return {
+        ok: false,
+        code: 'INVALID_TARGET',
+        error: invalidWeapon
+          ? `Weapon '${invalidWeapon.id}' cannot target '${target.id}'`
+          : `Target '${target.id}' is not valid for the selected weapon(s)`,
       }
     }
 

--- a/src/engine/units.ts
+++ b/src/engine/units.ts
@@ -30,6 +30,20 @@ export type WeaponStatus = 'ready' | 'spent' | 'destroyed'
 /**
  * A weapon system that a unit can use to attack.
  */
+export interface TargetRules {
+  /** Unit types this weapon or unit may target. */
+  allowedTargetUnitTypes?: ReadonlyArray<UnitType>
+  /** Weapon ids this weapon may target, when the target is a subsystem. */
+  allowedTargetWeaponIds?: ReadonlyArray<string>
+  /** Unit types that may target this unit. */
+  allowedAttackerUnitTypes?: ReadonlyArray<UnitType>
+  /** Weapon ids that may target this unit. */
+  allowedAttackerWeaponIds?: ReadonlyArray<string>
+}
+
+/**
+ * A weapon system that a unit can use to attack.
+ */
 export interface Weapon {
   /** Weapon identifier (e.g., 'main', 'secondary', 'ap', 'missile') */
   id: string
@@ -45,6 +59,8 @@ export interface Weapon {
   status: WeaponStatus
   /** Whether this weapon can be individually targeted (true for Onion subsystems) */
   individuallyTargetable: boolean
+  /** Optional target restrictions for this weapon. */
+  targetRules?: TargetRules
 }
 
 /**
@@ -115,6 +131,8 @@ export interface UnitDefinition {
   abilities: UnitAbilities
   /** Weapon systems */
   weapons: Weapon[]
+  /** Optional target restrictions for this unit. */
+  targetRules?: TargetRules
 }
 
 /**
@@ -133,6 +151,8 @@ export interface GameUnit {
   squads?: number
   /** Current weapon states */
   weapons: Weapon[]
+  /** Optional target restrictions for this live unit state. */
+  targetRules?: TargetRules
 }
 
 /**
@@ -295,9 +315,10 @@ function makeWeapon(
   attack: number,
   range: number,
   defense: number,
-  individuallyTargetable = false
+  individuallyTargetable = false,
+  targetRules?: TargetRules
 ): Weapon {
-  return { id, name, attack, range, defense, status: 'ready', individuallyTargetable }
+  return { id, name, attack, range, defense, status: 'ready', individuallyTargetable, targetRules }
 }
 
 const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
@@ -408,14 +429,14 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
       makeWeapon('secondary_2', 'Secondary Battery', 3, 2, 3, true),
       makeWeapon('secondary_3', 'Secondary Battery', 3, 2, 3, true),
       makeWeapon('secondary_4', 'Secondary Battery', 3, 2, 3, true),
-      makeWeapon('ap_1', 'AP Gun', 1, 1, 1, true),
-      makeWeapon('ap_2', 'AP Gun', 1, 1, 1, true),
-      makeWeapon('ap_3', 'AP Gun', 1, 1, 1, true),
-      makeWeapon('ap_4', 'AP Gun', 1, 1, 1, true),
-      makeWeapon('ap_5', 'AP Gun', 1, 1, 1, true),
-      makeWeapon('ap_6', 'AP Gun', 1, 1, 1, true),
-      makeWeapon('ap_7', 'AP Gun', 1, 1, 1, true),
-      makeWeapon('ap_8', 'AP Gun', 1, 1, 1, true),
+      makeWeapon('ap_1', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
+      makeWeapon('ap_2', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
+      makeWeapon('ap_3', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
+      makeWeapon('ap_4', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
+      makeWeapon('ap_5', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
+      makeWeapon('ap_6', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
+      makeWeapon('ap_7', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
+      makeWeapon('ap_8', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
       makeWeapon('missile_1', 'Missile', 6, 5, 3, true),
       makeWeapon('missile_2', 'Missile', 6, 5, 3, true),
     ],

--- a/src/engine/units.ts
+++ b/src/engine/units.ts
@@ -5,6 +5,7 @@
  */
 
 import type { HexPos, UnitStatus, TurnPhase } from '../types/index.js'
+import type { TargetRules } from '../shared/targetRules.js'
 import logger from '../logger.js'
 import { onionMovementAllowance } from '../shared/movementAllowance.js'
 
@@ -26,20 +27,6 @@ export type UnitType =
  * Status that a weapon can have.
  */
 export type WeaponStatus = 'ready' | 'spent' | 'destroyed'
-
-/**
- * A weapon system that a unit can use to attack.
- */
-export interface TargetRules {
-  /** Unit types this weapon or unit may target. */
-  allowedTargetUnitTypes?: ReadonlyArray<UnitType>
-  /** Weapon ids this weapon may target, when the target is a subsystem. */
-  allowedTargetWeaponIds?: ReadonlyArray<string>
-  /** Unit types that may target this unit. */
-  allowedAttackerUnitTypes?: ReadonlyArray<UnitType>
-  /** Weapon ids that may target this unit. */
-  allowedAttackerWeaponIds?: ReadonlyArray<string>
-}
 
 /**
  * A weapon system that a unit can use to attack.

--- a/src/shared/targetRules.ts
+++ b/src/shared/targetRules.ts
@@ -1,0 +1,79 @@
+export type TargetRules = {
+	allowedTargetUnitTypes?: ReadonlyArray<string>
+	allowedTargetWeaponIds?: ReadonlyArray<string>
+	allowedAttackerUnitTypes?: ReadonlyArray<string>
+	allowedAttackerWeaponIds?: ReadonlyArray<string>
+}
+
+export type TargetRuleActor = {
+	unitType: string
+	weaponId?: string
+	targetRules?: TargetRules
+}
+
+export type TargetRuleTarget = {
+	unitType: string
+	weaponId?: string
+	targetRules?: TargetRules
+}
+
+export type TargetRuleWeaponDefinition = {
+	id: string
+	targetRules?: TargetRules
+}
+
+export type TargetRuleUnitDefinition = {
+	targetRules?: TargetRules
+	weapons?: ReadonlyArray<TargetRuleWeaponDefinition>
+}
+
+function includesTargetRuleValue(values: ReadonlyArray<string> | undefined, value: string | undefined): boolean {
+	if (values === undefined) {
+		return true
+	}
+
+	if (value === undefined) {
+		return false
+	}
+
+	return values.includes(value)
+}
+
+export function isTargetAllowedByRules(actor: TargetRuleActor, target: TargetRuleTarget): boolean {
+	if (!includesTargetRuleValue(actor.targetRules?.allowedTargetUnitTypes, target.unitType)) {
+		return false
+	}
+
+	if (!includesTargetRuleValue(actor.targetRules?.allowedTargetWeaponIds, target.weaponId)) {
+		return false
+	}
+
+	if (!includesTargetRuleValue(target.targetRules?.allowedAttackerUnitTypes, actor.unitType)) {
+		return false
+	}
+
+	if (!includesTargetRuleValue(target.targetRules?.allowedAttackerWeaponIds, actor.weaponId)) {
+		return false
+	}
+
+	return true
+}
+
+export function resolveWeaponTargetRules(
+	unitDefinition: TargetRuleUnitDefinition | undefined,
+	weaponId: string,
+	liveTargetRules?: TargetRules,
+): TargetRules | undefined {
+	if (liveTargetRules !== undefined) {
+		return liveTargetRules
+	}
+
+	return unitDefinition?.weapons?.find((weapon) => weapon.id === weaponId)?.targetRules
+}
+
+export function resolveUnitTargetRules(
+	unitDefinition: TargetRuleUnitDefinition | undefined,
+	liveTargetRules?: TargetRules,
+): TargetRules | undefined {
+	return liveTargetRules ?? unitDefinition?.targetRules
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,23 @@ export type PlayerRole = 'onion' | 'defender'
 
 export type OnionWeaponType = 'main' | 'secondary' | 'ap' | 'missile'
 
+/**
+ * Explicit targeting restrictions for a weapon definition.
+ *
+ * Use explicit unit and weapon identifiers instead of abstract combat classes
+ * so special-case rules remain easy to read and extend.
+ */
+export interface TargetRules {
+  /** Unit types this weapon may target. */
+  allowedTargetUnitTypes?: ReadonlyArray<string>
+  /** Weapon ids this weapon may target, when the target is a subsystem. */
+  allowedTargetWeaponIds?: ReadonlyArray<string>
+  /** Unit types that may target this unit. */
+  allowedAttackerUnitTypes?: ReadonlyArray<string>
+  /** Weapon ids that may target this unit. */
+  allowedAttackerWeaponIds?: ReadonlyArray<string>
+}
+
 export interface HexPos {
   q: number
   r: number
@@ -26,6 +43,8 @@ export interface Weapon {
   defense: number
   status: WeaponStatus
   individuallyTargetable: boolean
+  /** Optional target restrictions for this weapon. */
+  targetRules?: TargetRules
 }
 
 export interface DefenderUnit {
@@ -35,6 +54,7 @@ export interface DefenderUnit {
   status: UnitStatus
   weapons?: Weapon[]
   squads?: number
+  targetRules?: TargetRules
 }
 
 export interface GameState {
@@ -46,6 +66,7 @@ export interface GameState {
     missiles?: number
     status?: UnitStatus
     weapons?: Weapon[]
+    targetRules?: TargetRules
     batteries?: {
       main: number
       secondary: number

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,22 +13,9 @@ export type PlayerRole = 'onion' | 'defender'
 
 export type OnionWeaponType = 'main' | 'secondary' | 'ap' | 'missile'
 
-/**
- * Explicit targeting restrictions for a weapon definition.
- *
- * Use explicit unit and weapon identifiers instead of abstract combat classes
- * so special-case rules remain easy to read and extend.
- */
-export interface TargetRules {
-  /** Unit types this weapon may target. */
-  allowedTargetUnitTypes?: ReadonlyArray<string>
-  /** Weapon ids this weapon may target, when the target is a subsystem. */
-  allowedTargetWeaponIds?: ReadonlyArray<string>
-  /** Unit types that may target this unit. */
-  allowedAttackerUnitTypes?: ReadonlyArray<string>
-  /** Weapon ids that may target this unit. */
-  allowedAttackerWeaponIds?: ReadonlyArray<string>
-}
+export type { TargetRules } from '../shared/targetRules.js'
+
+import type { TargetRules } from '../shared/targetRules.js'
 
 export interface HexPos {
   q: number

--- a/web/src/App.orchestration.test.tsx
+++ b/web/src/App.orchestration.test.tsx
@@ -443,6 +443,53 @@ describe('App orchestration (injected game client)', () => {
 		expect(screen.getByText(/No valid targets are currently in range/i)).not.toBeNull()
 	})
 
+	it('does not resurrect the previous combat toast when replaying the same attack after clearing selection', async () => {
+		const user = userEvent.setup()
+		const snapshot = createInRangeCombatSnapshot()
+		const resolvedSnapshot = {
+			...snapshot,
+			combatResolution: {
+				actionType: 'FIRE' as const,
+				attackers: ['wolf-2'],
+				targetId: 'onion-1',
+				outcome: 'X' as const,
+				outcomeLabel: 'Hit' as const,
+				roll: 6,
+				odds: '2:1',
+				details: ['Treads lost: 3 (remaining 30)'],
+			},
+		}
+		const session = { role: 'defender' as const }
+		const submitAction = vi.fn().mockResolvedValue(resolvedSnapshot)
+
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session }),
+			submitAction,
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} />)
+
+		await screen.findByTestId('combat-unit-wolf-2')
+		await user.click(screen.getByTestId('combat-unit-wolf-2'))
+		await user.click(screen.getByTestId('combat-target-onion-1:treads'))
+		await user.click(screen.getByRole('button', { name: /resolve combat/i }))
+
+		expect(await screen.findByTestId('combat-resolution-toast')).not.toBeNull()
+
+		await user.click(screen.getByTestId('hex-cell-0-0'))
+		expect(screen.queryByTestId('combat-resolution-toast')).toBeNull()
+
+		await user.click(screen.getByTestId('combat-unit-wolf-2'))
+		await user.click(screen.getByTestId('combat-target-onion-1:treads'))
+
+		expect(screen.getByTestId('combat-confirmation-view').textContent).toContain('Confirm attack on Treads')
+		expect(screen.queryByTestId('combat-resolution-toast')).toBeNull()
+
+		await user.click(screen.getByRole('button', { name: /resolve combat/i }))
+		expect(await screen.findByTestId('combat-resolution-toast')).not.toBeNull()
+	})
+
 	it('submits a move when the active player right-clicks an in-range hex', async () => {
 		const snapshot = createConnectedBattlefieldSnapshot({
 			phase: 'DEFENDER_MOVE',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -201,6 +201,7 @@ function buildLiveDefenders(snapshot: GameSnapshot, activePhase: TurnPhase | nul
       weapons: formatWeaponSummary(defender.weapons),
       attack: formatAttackSummary(defender.weapons),
       weaponDetails: defender.weapons ?? [],
+      targetRules: defender.targetRules,
       defense: getDisplayDefense(defender.type, defender.squads, getTerrainTypeAt(snapshot.scenarioMap, defender.position.q, defender.position.r)),
       squads: defender.squads,
       actionableModes: getActionableModes(defender.status, defender.weapons, activeTurnActive),
@@ -249,6 +250,7 @@ function buildLiveOnion(snapshot: GameSnapshot, activePhase: TurnPhase | null): 
     rams: authoritativeState.ramsThisTurn ?? 0,
     weapons: formatWeaponSummary(onion.weapons),
     weaponDetails: onion.weapons ?? [],
+    targetRules: onion.targetRules,
   }
 }
 
@@ -480,16 +482,22 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
     }
   }
 
-  function handleDismissCombatResolution() {
-    if (pendingCombatSnapshot === null) {
-      return
+  function clearPendingCombatResolution(clearSelection: boolean) {
+    if (pendingCombatSnapshot !== null) {
+      setClientSnapshot(pendingCombatSnapshot)
     }
 
-    setClientSnapshot(pendingCombatSnapshot)
     setPendingCombatSnapshot(null)
     setPendingCombatResolution(null)
-    setSelectedUnitIds([])
-    setSelectedCombatTargetId(null)
+
+    if (clearSelection) {
+      setSelectedUnitIds([])
+      setSelectedCombatTargetId(null)
+    }
+  }
+
+  function handleDismissCombatResolution() {
+    clearPendingCombatResolution(true)
   }
 
   function handleConfirmCombat() {
@@ -551,6 +559,8 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
       return
     }
 
+    clearPendingCombatResolution(false)
+
     setSelectedUnitIds((currentSelection) => {
       const baseSelection = currentSelection ?? (clientSnapshot?.selectedUnitId ? [clientSnapshot.selectedUnitId] : [])
 
@@ -569,6 +579,7 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
   }
 
   function handleDeselectUnit() {
+    clearPendingCombatResolution(false)
     setSelectedUnitIds([])
     setSelectedCombatTargetId(null)
     setActionError(null)
@@ -653,6 +664,7 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
     }),
     [activeCombatRole, activeSelectedUnitIds, combatRangeHexKeys, displayedDefenders, displayedOnion, selectedCombatAttackStrength, displayedScenarioMap],
   )
+  const combatTargetIds = useMemo(() => new Set(combatTargetOptions.map((target) => target.id)), [combatTargetOptions])
   const selectedCombatTarget = selectedCombatTargetId === null ? null : combatTargetOptions.find((target) => target.id === selectedCombatTargetId) ?? null
 
   useEffect(() => {
@@ -1111,6 +1123,7 @@ function App({ gameClient, gameId, runtimeConfig, showConnectionGate = false }: 
                 selectedUnitIds={activeSelectedUnitIds}
                 selectedCombatTargetId={selectedCombatTargetId}
                 combatRangeHexKeys={combatRangeHexKeys}
+                combatTargetIds={combatTargetIds}
                 canSubmitMove={
                   activeTurnActive && (
                     activePhase === 'ONION_MOVE' ||

--- a/web/src/components/CombatConfirmationView.tsx
+++ b/web/src/components/CombatConfirmationView.tsx
@@ -52,7 +52,14 @@ export function CombatConfirmationView({ title, attackStrength, defenseStrength,
 
       {onConfirm ? (
         <div className="combat-confirmation-actions">
-          <button className="combat-confirm-button" type="button" onClick={onConfirm}>
+          <button
+            className="combat-confirm-button"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation()
+              onConfirm()
+            }}
+          >
             {confirmLabel ?? 'Confirm attack'}
           </button>
         </div>

--- a/web/src/components/CombatResolutionToast.tsx
+++ b/web/src/components/CombatResolutionToast.tsx
@@ -75,7 +75,14 @@ export function CombatResolutionToast({ title, resolution, modifiers, onDismiss 
 			</div>
 
 			<div className="combat-resolution-actions">
-				<button className="combat-resolution-dismiss" type="button" onClick={onDismiss}>
+				<button
+					className="combat-resolution-dismiss"
+					type="button"
+					onClick={(event) => {
+						event.stopPropagation()
+						onDismiss()
+					}}
+				>
 					Dismiss
 				</button>
 			</div>

--- a/web/src/components/HexMapBoard.test.tsx
+++ b/web/src/components/HexMapBoard.test.tsx
@@ -198,6 +198,30 @@ describe('HexMapBoard', () => {
 		expect(onSelectCombatTarget).toHaveBeenCalledWith('puss-1')
 	})
 
+	it('does not select a combat target that is not in the legal target set', () => {
+		const onSelectCombatTarget = vi.fn()
+
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={defenders}
+				onion={onion}
+				phase="ONION_COMBAT"
+				selectedUnitIds={['weapon:ap_2']}
+				combatTargetIds={new Set(['puss-1'])}
+				selectedCombatTargetId={null}
+				onSelectUnit={vi.fn()}
+				onSelectCombatTarget={onSelectCombatTarget}
+				onDeselect={vi.fn()}
+				onMoveUnit={vi.fn()}
+			/>,
+		)
+
+		fireEvent.contextMenu(screen.getByTestId('hex-unit-wolf-2'))
+		expect(onSelectCombatTarget).not.toHaveBeenCalled()
+		expect(screen.getByTestId('hex-unit-wolf-2').getAttribute('data-selected')).toBe('false')
+	})
+
 	it('highlights every selected unit across the board when a selection group is active', () => {
 		const onSelectUnit = vi.fn()
 		const sharedOnion: BattlefieldOnionView = {

--- a/web/src/components/HexMapBoard.test.tsx
+++ b/web/src/components/HexMapBoard.test.tsx
@@ -198,6 +198,31 @@ describe('HexMapBoard', () => {
 		expect(onSelectCombatTarget).toHaveBeenCalledWith('puss-1')
 	})
 
+	it('maps defender combat clicks on the Onion to the treads target id', () => {
+		const onSelectCombatTarget = vi.fn()
+
+		render(
+			<HexMapBoard
+				scenarioMap={scenarioMap}
+				defenders={defenders}
+				onion={onion}
+				phase="DEFENDER_COMBAT"
+				selectedUnitIds={['puss-1']}
+				selectedCombatTargetId={'onion-1:treads'}
+				combatTargetIds={new Set(['onion-1:treads', 'weapon:main'])}
+				onSelectUnit={vi.fn()}
+				onSelectCombatTarget={onSelectCombatTarget}
+				onDeselect={vi.fn()}
+				onMoveUnit={vi.fn()}
+			/>,
+		)
+
+		fireEvent.click(screen.getByTestId('hex-unit-onion-1'))
+		expect(onSelectCombatTarget).toHaveBeenCalledWith('onion-1:treads')
+		expect(screen.getByTestId('hex-unit-onion-1').getAttribute('data-selected')).toBe('false')
+		expect(screen.getByTestId('hex-cell-0-0').getAttribute('class')).toContain('hex-cell-selected')
+	})
+
 	it('does not select a combat target that is not in the legal target set', () => {
 		const onSelectCombatTarget = vi.fn()
 

--- a/web/src/components/HexMapBoard.tsx
+++ b/web/src/components/HexMapBoard.tsx
@@ -19,6 +19,7 @@ type HexMapBoardProps = {
   selectedUnitIds: string[]
   selectedCombatTargetId?: string | null
   combatRangeHexKeys?: ReadonlySet<string>
+  combatTargetIds?: ReadonlySet<string>
   canSubmitMove?: boolean
   onSelectUnit: (unitId: string, additive?: boolean) => void
   onSelectCombatTarget?: (targetId: string) => void
@@ -46,7 +47,7 @@ function getStackOffset(index: number, total: number): { dx: number; dy: number 
   }
 }
 
-export function HexMapBoard({ scenarioMap, defenders, onion, phase, selectedUnitIds, selectedCombatTargetId, combatRangeHexKeys, canSubmitMove = true, onSelectUnit, onSelectCombatTarget, onDeselect, onMoveUnit }: HexMapBoardProps) {
+export function HexMapBoard({ scenarioMap, defenders, onion, phase, selectedUnitIds, selectedCombatTargetId, combatRangeHexKeys, combatTargetIds, canSubmitMove = true, onSelectUnit, onSelectCombatTarget, onDeselect, onMoveUnit }: HexMapBoardProps) {
   const terrain = new Map(scenarioMap.hexes.map((hex) => [hexKey(hex), hex.t]))
   const occupantMap = new Map<string, HexOccupant[]>()
   const [moveError, setMoveError] = useState<{ message: string; x: number; y: number } | null>(null)
@@ -145,19 +146,19 @@ export function HexMapBoard({ scenarioMap, defenders, onion, phase, selectedUnit
     }
 
     if (activeCombatRole === 'onion') {
-      return occupant.id !== onion.id
+      return occupant.id !== onion.id && (combatTargetIds === undefined || combatTargetIds.has(occupant.id))
     }
 
-    return occupant.id === onion.id ? false : activeCombatRole === 'defender'
+    return occupant.id !== onion.id
   }
 
   function selectCombatTarget(occupant: HexOccupant) {
-    if (activeCombatRole === 'onion' && occupant.id !== onion.id) {
+    if (activeCombatRole === 'onion' && occupant.id !== onion.id && (combatTargetIds === undefined || combatTargetIds.has(occupant.id))) {
       onSelectCombatTarget?.(occupant.id)
       return true
     }
 
-    if (activeCombatRole === 'defender' && occupant.id === onion.id) {
+    if (activeCombatRole === 'defender' && occupant.id === onion.id && (combatTargetIds === undefined || combatTargetIds.has(occupant.id))) {
       onSelectCombatTarget?.(occupant.id)
       return true
     }

--- a/web/src/components/HexMapBoard.tsx
+++ b/web/src/components/HexMapBoard.tsx
@@ -140,26 +140,38 @@ export function HexMapBoard({ scenarioMap, defenders, onion, phase, selectedUnit
 
   const bounds = boardPixelSize(scenarioMap.width, scenarioMap.height, HEX_SIZE, MAP_PADDING)
 
+  function getCombatTargetIdForOccupant(occupant: HexOccupant): string {
+    if (activeCombatRole === 'defender' && occupant.id === onion.id) {
+      return `${onion.id}:treads`
+    }
+
+    return occupant.id
+  }
+
   function canSelectOccupant(occupant: HexOccupant): boolean {
     if (activeCombatRole === null) {
       return true
     }
 
+    const combatTargetId = getCombatTargetIdForOccupant(occupant)
+
     if (activeCombatRole === 'onion') {
-      return occupant.id !== onion.id && (combatTargetIds === undefined || combatTargetIds.has(occupant.id))
+      return occupant.id !== onion.id && (combatTargetIds === undefined || combatTargetIds.has(combatTargetId))
     }
 
-    return occupant.id !== onion.id
+    return occupant.id === onion.id && (combatTargetIds === undefined || combatTargetIds.has(combatTargetId))
   }
 
   function selectCombatTarget(occupant: HexOccupant) {
-    if (activeCombatRole === 'onion' && occupant.id !== onion.id && (combatTargetIds === undefined || combatTargetIds.has(occupant.id))) {
-      onSelectCombatTarget?.(occupant.id)
+    const combatTargetId = getCombatTargetIdForOccupant(occupant)
+
+    if (activeCombatRole === 'onion' && occupant.id !== onion.id && (combatTargetIds === undefined || combatTargetIds.has(combatTargetId))) {
+      onSelectCombatTarget?.(combatTargetId)
       return true
     }
 
-    if (activeCombatRole === 'defender' && occupant.id === onion.id && (combatTargetIds === undefined || combatTargetIds.has(occupant.id))) {
-      onSelectCombatTarget?.(occupant.id)
+    if (activeCombatRole === 'defender' && occupant.id === onion.id && (combatTargetIds === undefined || combatTargetIds.has(combatTargetId))) {
+      onSelectCombatTarget?.(combatTargetId)
       return true
     }
 
@@ -191,7 +203,14 @@ export function HexMapBoard({ scenarioMap, defenders, onion, phase, selectedUnit
               const cellOccupants = occupantMap.get(hexKey(coord)) ?? []
               const isOnion = cellOccupants.some((occupant) => occupant.id === onion.id)
               const isSelected = cellOccupants.some((occupant) => selectedUnitSet.has(occupant.id))
-              const isCombatTargetSelected = selectedCombatTargetId !== undefined && selectedCombatTargetId !== null && cellOccupants.some((occupant) => occupant.id === selectedCombatTargetId)
+              const isCombatTargetSelected = selectedCombatTargetId !== undefined && selectedCombatTargetId !== null && cellOccupants.some((occupant) => {
+                const combatTargetId = getCombatTargetIdForOccupant(occupant)
+
+                return combatTargetId === selectedCombatTargetId
+                  || (activeCombatRole === 'defender' && occupant.id === onion.id && (
+                    selectedCombatTargetId.startsWith(`${onion.id}:`) || selectedCombatTargetId.startsWith('weapon:')
+                  ))
+              })
               const isCombatRange = combatRangeHexKeys?.has(hexKey(coord)) ?? false
               const isMoveReady = canSubmitMove && cellOccupants.some(
                 (occupant) => playerRole && isUnitMoveEligible(occupant, phase, playerRole)
@@ -283,7 +302,15 @@ export function HexMapBoard({ scenarioMap, defenders, onion, phase, selectedUnit
                           event.stopPropagation()
                           if (activeCombatRole === 'onion' && occupant.id !== onion.id) {
                             if (onSelectCombatTarget !== undefined) {
-                              onSelectCombatTarget(occupant.id)
+                              onSelectCombatTarget(getCombatTargetIdForOccupant(occupant))
+                            }
+
+                            return
+                          }
+
+                          if (activeCombatRole === 'defender' && occupant.id === onion.id) {
+                            if (onSelectCombatTarget !== undefined) {
+                              onSelectCombatTarget(getCombatTargetIdForOccupant(occupant))
                             }
 
                             return

--- a/web/src/lib/battlefieldView.ts
+++ b/web/src/lib/battlefieldView.ts
@@ -1,4 +1,4 @@
-import type { Weapon } from '../../../src/types/index'
+import type { TargetRules, Weapon } from '../../../src/types/index'
 
 // Returns true if the unit is eligible to move for the given player and phase
 export function isUnitMoveEligible(
@@ -34,6 +34,7 @@ export type BattlefieldUnit = {
   defense?: number
   squads?: number
   weaponDetails?: ReadonlyArray<Weapon>
+  targetRules?: TargetRules
   actionableModes: Mode[]
 }
 
@@ -49,6 +50,7 @@ export type BattlefieldOnionView = {
   rams: number
   weapons: string
   weaponDetails?: ReadonlyArray<Weapon>
+  targetRules?: TargetRules
 }
 
 export type TimelineEvent = {

--- a/web/src/lib/combatPreview.test.ts
+++ b/web/src/lib/combatPreview.test.ts
@@ -198,4 +198,58 @@ describe('buildCombatTargetOptions', () => {
 
 		expect(options.map((option) => option.id)).toEqual(['castle-1'])
 	})
+
+	it('still offers defender combat targets on the Onion', () => {
+		const options = buildCombatTargetOptions({
+			activeCombatRole: 'defender',
+			combatRangeHexKeys: new Set(['0,0']),
+			displayedDefenders: [
+				{
+					id: 'wolf-2',
+					type: 'BigBadWolf',
+					status: 'operational',
+					q: 1,
+					r: 1,
+					move: 4,
+					weapons: 'main: ready',
+					attack: '2 / rng 2',
+					defense: 4,
+					actionableModes: ['fire'],
+				},
+			],
+			displayedOnion: {
+				id: 'onion-1',
+				type: 'TheOnion',
+				q: 0,
+				r: 0,
+				status: 'operational',
+				treads: 33,
+				movesAllowed: 0,
+				movesRemaining: 0,
+				rams: 0,
+				weapons: 'main: ready',
+				weaponDetails: [
+					{
+						id: 'ap_1',
+						name: 'AP Gun',
+						attack: 1,
+						range: 1,
+						defense: 1,
+						status: 'ready',
+						individuallyTargetable: true,
+						targetRules: { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] },
+					},
+				],
+			},
+			selectedUnitIds: ['wolf-2'],
+			selectedAttackStrength: 2,
+			displayedScenarioMap: {
+				width: 8,
+				height: 8,
+				hexes: [],
+			},
+		})
+
+		expect(options.map((option) => option.id)).toEqual(['onion-1:treads', 'weapon:ap_1'])
+	})
 })

--- a/web/src/lib/combatPreview.test.ts
+++ b/web/src/lib/combatPreview.test.ts
@@ -53,4 +53,149 @@ describe('buildCombatTargetOptions', () => {
 			modifiers: expect.arrayContaining(['Ridgeline cover: +1 defense']),
 		})
 	})
+
+	it('filters AP targets to infantry and Castle only', () => {
+		const options = buildCombatTargetOptions({
+			activeCombatRole: 'onion',
+			combatRangeHexKeys: new Set(['1,0', '1,1', '2,1']),
+			displayedDefenders: [
+				{
+					id: 'wolf-1',
+					type: 'BigBadWolf',
+					status: 'operational',
+					q: 1,
+					r: 0,
+					move: 0,
+					weapons: 'main: ready',
+					attack: '2 / rng 2',
+					defense: 4,
+					actionableModes: ['fire'],
+				},
+				{
+					id: 'pigs-1',
+					type: 'LittlePigs',
+					status: 'operational',
+					q: 1,
+					r: 1,
+					move: 0,
+					weapons: 'rifle: ready',
+					attack: '1 / rng 1',
+					defense: 2,
+					squads: 2,
+					actionableModes: ['fire'],
+				},
+				{
+					id: 'castle-1',
+					type: 'Castle',
+					status: 'operational',
+					q: 2,
+					r: 1,
+					move: 0,
+					weapons: '',
+					attack: '0 / rng 0',
+					defense: 0,
+					actionableModes: ['fire'],
+				},
+			],
+			displayedOnion: {
+				id: 'onion-1',
+				type: 'TheOnion',
+				q: 0,
+				r: 0,
+				status: 'operational',
+				treads: 33,
+				movesAllowed: 0,
+				movesRemaining: 0,
+				rams: 0,
+				weapons: 'ap: ready',
+				weaponDetails: [
+					{
+						id: 'ap_1',
+						name: 'AP Gun',
+						attack: 1,
+						range: 1,
+						defense: 1,
+						status: 'ready',
+						individuallyTargetable: true,
+					},
+				],
+			},
+			selectedUnitIds: ['weapon:ap_1'],
+			selectedAttackStrength: 1,
+			displayedScenarioMap: {
+				width: 8,
+				height: 8,
+				hexes: [],
+			},
+		})
+
+		expect(options.map((option) => option.id)).toEqual(['pigs-1', 'castle-1'])
+	})
+
+	it('honors target-unit restrictions in the target selector', () => {
+		const options = buildCombatTargetOptions({
+			activeCombatRole: 'onion',
+			combatRangeHexKeys: new Set(['1,0', '1,1', '2,1']),
+			displayedDefenders: [
+				{
+					id: 'pigs-1',
+					type: 'LittlePigs',
+					status: 'operational',
+					q: 1,
+					r: 1,
+					move: 0,
+					weapons: 'rifle: ready',
+					attack: '1 / rng 1',
+					defense: 2,
+					squads: 2,
+					targetRules: { allowedAttackerUnitTypes: ['BigBadWolf'] },
+					actionableModes: ['fire'],
+				},
+				{
+					id: 'castle-1',
+					type: 'Castle',
+					status: 'operational',
+					q: 2,
+					r: 1,
+					move: 0,
+					weapons: '',
+					attack: '0 / rng 0',
+					defense: 0,
+					actionableModes: ['fire'],
+				},
+			],
+			displayedOnion: {
+				id: 'onion-1',
+				type: 'TheOnion',
+				q: 0,
+				r: 0,
+				status: 'operational',
+				treads: 33,
+				movesAllowed: 0,
+				movesRemaining: 0,
+				rams: 0,
+				weapons: 'ap: ready',
+				weaponDetails: [
+					{
+						id: 'ap_1',
+						name: 'AP Gun',
+						attack: 1,
+						range: 1,
+						defense: 1,
+						status: 'ready',
+						individuallyTargetable: true,
+					},
+				],
+			},
+			selectedUnitIds: ['weapon:ap_1'],
+			selectedAttackStrength: 1,
+			displayedScenarioMap: {
+				width: 8,
+				height: 8,
+				hexes: [],
+			},
+		})
+
+		expect(options.map((option) => option.id)).toEqual(['castle-1'])
+	})
 })

--- a/web/src/lib/combatPreview.ts
+++ b/web/src/lib/combatPreview.ts
@@ -84,14 +84,6 @@ function getWeaponDetails(displayedOnion: BattlefieldOnionView): ReadonlyArray<W
 	return displayedOnion.weaponDetails ?? []
 }
 
-function getStaticWeaponTargetRules(weaponId: string) {
-	return combatRules.unitDefinitions.TheOnion.weapons.find((weapon) => weapon.id === weaponId)?.targetRules
-}
-
-function getStaticUnitTargetRules(unitType: string) {
-	return combatRules.unitDefinitions[unitType]?.targetRules
-}
-
 function getSelectedWeapons(displayedOnion: BattlefieldOnionView, selectedAttackerIds: ReadonlyArray<string>): ReadonlyArray<Weapon> {
 	const selectedWeaponIds = new Set(selectedAttackerIds)
 	return getWeaponDetails(displayedOnion).filter((weapon) => selectedWeaponIds.has(weapon.id))
@@ -190,11 +182,11 @@ export function buildCombatTargetOptions({
 						{
 							unitType: 'TheOnion',
 							weaponId: weapon.id,
-							targetRules: resolveWeaponTargetRules(combatRules.unitDefinitions.TheOnion, weapon.id, weapon.targetRules ?? getStaticWeaponTargetRules(weapon.id)),
+							targetRules: resolveWeaponTargetRules(combatRules.unitDefinitions.TheOnion, weapon.id, weapon.targetRules),
 						},
 						{
 							unitType: unit.type,
-							targetRules: resolveUnitTargetRules(combatRules.unitDefinitions[unit.type], unit.targetRules ?? getStaticUnitTargetRules(unit.type)),
+							targetRules: resolveUnitTargetRules(combatRules.unitDefinitions[unit.type], unit.targetRules),
 						},
 					),
 				),
@@ -227,19 +219,6 @@ export function buildCombatTargetOptions({
 
 	const readyWeaponTargets = getWeaponDetails(displayedOnion)
 		.filter((weapon) => weapon.individuallyTargetable && weapon.status === 'ready')
-		.filter((weapon) =>
-			isTargetAllowedByRules(
-				{
-					unitType: 'TheOnion',
-					weaponId: weapon.id,
-					targetRules: resolveWeaponTargetRules(combatRules.unitDefinitions.TheOnion, weapon.id, weapon.targetRules ?? getStaticWeaponTargetRules(weapon.id)),
-				},
-				{
-					unitType: displayedOnion.type,
-					targetRules: resolveUnitTargetRules(combatRules.unitDefinitions[displayedOnion.type], displayedOnion.targetRules ?? getStaticUnitTargetRules(displayedOnion.type)),
-				},
-			),
-		)
 		.map((weapon) => {
 			const result = combatCalculator.calculateResult(
 				buildCombatCalculatorInputForWeaponTarget(selectedAttackerIds, displayedDefenders, displayedOnion, weapon, displayedScenarioMap),

--- a/web/src/lib/combatPreview.ts
+++ b/web/src/lib/combatPreview.ts
@@ -5,6 +5,11 @@ import {
 	type CombatCalculatorInput,
 	type CombatStaticRules,
 } from '../../../src/shared/combatCalculator.js'
+import {
+	isTargetAllowedByRules,
+	resolveUnitTargetRules,
+	resolveWeaponTargetRules,
+} from '../../../src/shared/targetRules.js'
 
 import type { BattlefieldOnionView, BattlefieldUnit, TerrainHex, UnitStatus, Weapon } from './battlefieldView'
 
@@ -77,6 +82,19 @@ function getSelectedAttackerIds(activeCombatRole: CombatRole, selectedUnitIds: R
 
 function getWeaponDetails(displayedOnion: BattlefieldOnionView): ReadonlyArray<Weapon> {
 	return displayedOnion.weaponDetails ?? []
+}
+
+function getStaticWeaponTargetRules(weaponId: string) {
+	return combatRules.unitDefinitions.TheOnion.weapons.find((weapon) => weapon.id === weaponId)?.targetRules
+}
+
+function getStaticUnitTargetRules(unitType: string) {
+	return combatRules.unitDefinitions[unitType]?.targetRules
+}
+
+function getSelectedWeapons(displayedOnion: BattlefieldOnionView, selectedAttackerIds: ReadonlyArray<string>): ReadonlyArray<Weapon> {
+	const selectedWeaponIds = new Set(selectedAttackerIds)
+	return getWeaponDetails(displayedOnion).filter((weapon) => selectedWeaponIds.has(weapon.id))
 }
 
 function buildCombatCalculatorInputForDefenderTarget(
@@ -162,9 +180,25 @@ export function buildCombatTargetOptions({
 	}
 
 	if (activeCombatRole === 'onion') {
+		const selectedWeapons = getSelectedWeapons(displayedOnion!, selectedAttackerIds)
 		return displayedDefenders
 			.filter((unit) => unit.status !== 'destroyed')
 			.filter((unit) => combatRangeHexKeys.has(`${unit.q},${unit.r}`))
+			.filter((unit) =>
+				selectedWeapons.every((weapon) =>
+					isTargetAllowedByRules(
+						{
+							unitType: 'TheOnion',
+							weaponId: weapon.id,
+							targetRules: resolveWeaponTargetRules(combatRules.unitDefinitions.TheOnion, weapon.id, weapon.targetRules ?? getStaticWeaponTargetRules(weapon.id)),
+						},
+						{
+							unitType: unit.type,
+							targetRules: resolveUnitTargetRules(combatRules.unitDefinitions[unit.type], unit.targetRules ?? getStaticUnitTargetRules(unit.type)),
+						},
+					),
+				),
+			)
 			.map((unit) => {
 				const result = combatCalculator.calculateResult(
 					buildCombatCalculatorInputForDefenderTarget(selectedAttackerIds, displayedOnion!, unit, displayedScenarioMap),
@@ -193,6 +227,19 @@ export function buildCombatTargetOptions({
 
 	const readyWeaponTargets = getWeaponDetails(displayedOnion)
 		.filter((weapon) => weapon.individuallyTargetable && weapon.status === 'ready')
+		.filter((weapon) =>
+			isTargetAllowedByRules(
+				{
+					unitType: 'TheOnion',
+					weaponId: weapon.id,
+					targetRules: resolveWeaponTargetRules(combatRules.unitDefinitions.TheOnion, weapon.id, weapon.targetRules ?? getStaticWeaponTargetRules(weapon.id)),
+				},
+				{
+					unitType: displayedOnion.type,
+					targetRules: resolveUnitTargetRules(combatRules.unitDefinitions[displayedOnion.type], displayedOnion.targetRules ?? getStaticUnitTargetRules(displayedOnion.type)),
+				},
+			),
+		)
 		.map((weapon) => {
 			const result = combatCalculator.calculateResult(
 				buildCombatCalculatorInputForWeaponTarget(selectedAttackerIds, displayedDefenders, displayedOnion, weapon, displayedScenarioMap),


### PR DESCRIPTION
This PR wires the combat phase into the UI, introduces explicit AP targeting rules, updates docs/specs, and adds focused tests for target legality. Includes static-definition fallback for target rules and ensures the UI/backend share a single source of truth for legal combat targets.