### PR TITLE
refactor(shared): consolidate the rules platform

### DIFF
--- a/docs/shared-rules-platform-refactor-spec.md
+++ b/docs/shared-rules-platform-refactor-spec.md
@@ -2,7 +2,7 @@
 
 **Status: In Progress (April 2026)**
 
-Status: Phase 2 complete
+Status: Phase 3 complete
 Date: 2026-04-13
 Branch: `feature/shared-rules-platform-refactor`
 
@@ -182,6 +182,8 @@ Exit criteria:
 
 ### Phase 3: Extract Shared Ramming Calculator
 
+Status: Complete on 2026-04-13
+
 Deliverables:
 
 1. create `shared/rammingCalculator.ts`
@@ -223,5 +225,5 @@ Recommended test order:
 - [x] Replace `MOVEMENT_PROFILES` with definition-derived movement queries
 - [x] Extract shared occupancy and stack rules out of `shared/movePlanner.ts`
 - [x] Update engine movement validation to use shared movement-rule queries
-- [ ] Add a pure shared ramming calculator and migrate engine movement to it
+- [x] Add a pure shared ramming calculator and migrate engine movement to it
 - [ ] Document the final canonical static rules bundle and schema-ready boundary

--- a/docs/shared-rules-platform-refactor-spec.md
+++ b/docs/shared-rules-platform-refactor-spec.md
@@ -1,0 +1,227 @@
+# Shared Rules Platform Refactor Spec
+
+**Status: In Progress (April 2026)**
+
+Status: Phase 2 complete
+Date: 2026-04-13
+Branch: `feature/shared-rules-platform-refactor`
+
+## Purpose
+
+Treat the following three todo items as one rules-platform update rather than three unrelated tasks:
+
+1. externalize unit and weapon definitions so they can move cleanly to a shared data file or schema later
+2. collapse movement profiles, pathfinding, terrain-entry rules, cover rules, and stacking rules into one shared rules model
+3. add a standalone shared ramming calculator that consumes the same unit capability data
+
+The current codebase already has part of this shape in `shared/unitDefinitions.ts`, `shared/engineTypes.ts`, `shared/movePlanner.ts`, `shared/unitMovement.ts`, and `shared/combatCalculator.ts`, but movement and ramming still depend on duplicated or hardcoded rule surfaces in engine code.
+
+## Current Problems
+
+1. Unit definitions are duplicated between `shared/unitDefinitions.ts` and `server/engine/units.ts`.
+2. Movement allowances and mobility flags are duplicated in `shared/unitMovement.ts` via `MOVEMENT_PROFILES` instead of being derived from shared unit definitions.
+3. `shared/movePlanner.ts` still hardcodes terrain costs, traversal, and Little Pigs stacking logic instead of asking a shared rule source.
+4. `server/engine/movement.ts` still duplicates destination-stacking checks and hardcodes ramming outcomes in `calculateRamming`.
+5. Combat already consumes shared definitions, so movement and ramming now lag behind the combat seam and increase the chance of rule drift.
+
+## Goals
+
+1. Make one shared static rules bundle the canonical source for unit, weapon, terrain, targeting, movement, stacking, cover, and ram-profile data.
+2. Move rule interpretation into pure shared helpers so engine and UI can consume the same behavior.
+3. Remove engine-local copies of unit definitions and movement profiles.
+4. Keep the resulting rule model shaped so it can later be serialized to JSON or validated against a schema with minimal churn.
+5. Keep the first refactor behavior-preserving unless a test explicitly documents an intended rules change.
+
+## Non-Goals
+
+1. No immediate switch to loading rules from external JSON files at runtime.
+2. No broad scenario-format migration beyond what is needed to reference shared rule ids cleanly.
+3. No redesign of combat resolution beyond wiring it to the consolidated rule source when useful.
+4. No UI feature expansion outside the seams needed to consume the new shared helpers.
+
+## Target Architecture
+
+The major update should leave the rules stack in four layers.
+
+### 1. Static Rule Data
+
+Responsibilities:
+
+1. declare unit and weapon definitions
+2. declare terrain interaction metadata
+3. declare ram profiles and stack limits
+4. declare target restrictions and any other static capability flags
+
+Suggested modules:
+
+1. `shared/unitDefinitions.ts` as the canonical source, or a small `shared/rules/` folder if the file becomes too large
+2. `shared/engineTypes.ts` as the stable type contract for rule data
+
+### 2. Shared Rule Queries
+
+Responsibilities:
+
+1. derive movement allowance by phase from static rule data
+2. answer terrain-entry and cover questions from unit and terrain definitions
+3. answer traversal and stopping legality from stack rules and occupant mix
+4. expose a small, reusable API for movement planning and move validation
+
+Suggested modules:
+
+1. `shared/unitMovement.ts` narrowed so it derives from canonical definitions instead of `MOVEMENT_PROFILES`
+2. new `shared/movementRules.ts` for terrain, traversal, stopping, and stack-limit decisions
+
+### 3. Pure Shared Calculators
+
+Responsibilities:
+
+1. movement pathfinding through `shared/movePlanner.ts`
+2. combat math through `shared/combatCalculator.ts`
+3. ramming outcomes through a new `shared/rammingCalculator.ts`
+
+Rule: these modules should consume static rules and shared query helpers, not embed rule tables.
+
+### 4. Engine Adapters
+
+Responsibilities:
+
+1. build live state snapshots for the pure shared calculators
+2. mutate authoritative game state after a validated result is returned
+3. emit API- and event-facing errors using the engine's existing result contracts
+
+Primary affected engine modules:
+
+1. `server/engine/units.ts`
+2. `server/engine/movement.ts`
+3. `server/engine/combat.ts`
+
+## Proposed Implementation Shape
+
+### Shared Static Rules Bundle
+
+Introduce one exported bundle that groups the canonical static data the calculators need.
+
+Minimum shape:
+
+1. `unitDefinitions`
+2. `terrainRules`
+3. optional future metadata for scenario or weapon categories if needed later
+
+That bundle should be stable enough to serialize later, even if it is still authored in TypeScript for now.
+
+### Shared Movement Rules API
+
+Add a pure rules-query layer that owns questions like:
+
+1. how much movement allowance does this unit have in this phase
+2. can this unit enter or cross this terrain
+3. can this unit benefit from terrain cover
+4. can this unit traverse an occupied hex
+5. can this unit stop on an occupied hex
+6. what is the max stack size for this unit type
+
+This should absorb the hardcoded logic currently split across `shared/unitMovement.ts`, `shared/movePlanner.ts`, and `server/engine/movement.ts`.
+
+### Shared Ramming Calculator
+
+Add a pure calculator that resolves ramming from static rule data plus a supplied die roll.
+
+Minimum responsibilities:
+
+1. derive tread cost from the rammed unit's rule profile
+2. derive destroyed versus surviving outcome from the same profile
+3. return a result shape the engine can apply without reinterpreting the rules
+
+The engine should stop deciding ramming behavior with local `if` chains.
+
+## Migration Plan
+
+### Phase 0: Freeze Spec And Tests
+
+Deliverables:
+
+1. this spec
+2. updated todo grouping the work as one major update
+3. red tests that pin the shared movement and ramming contracts before implementation changes
+
+Exit criteria:
+
+1. the canonical ownership split is explicit
+2. the first failing tests cover the new shared seams, not only engine wrappers
+
+### Phase 1: Canonicalize Static Rule Data
+
+Status: Complete on 2026-04-13
+
+Deliverables:
+
+1. remove duplicated unit-definition literals from `server/engine/units.ts`
+2. have engine exports re-export or adapt the shared definitions instead of owning a second copy
+3. add any missing terrain and ram-profile metadata required by movement and ramming
+
+Exit criteria:
+
+1. there is only one authored source of unit and weapon stats
+2. combat and engine helpers consume the same definition objects or a shared clone of them
+
+### Phase 2: Consolidate Movement Rule Queries
+
+Status: Complete on 2026-04-13
+
+Deliverables:
+
+1. derive `shared/unitMovement.ts` behavior from canonical definitions
+2. extract occupancy, stack, terrain-entry, and cover checks into shared rule-query helpers
+3. update `shared/movePlanner.ts` to depend on those helpers rather than hardcoded unit names or terrain cost branches
+4. remove duplicated destination-stacking logic from `server/engine/movement.ts`
+
+Exit criteria:
+
+1. movement legality decisions come from one shared rule layer
+2. engine movement is mostly orchestration plus state mutation
+
+### Phase 3: Extract Shared Ramming Calculator
+
+Deliverables:
+
+1. create `shared/rammingCalculator.ts`
+2. move tread-cost and destroy-survive logic out of `server/engine/movement.ts`
+3. update movement execution and API tests to consume the shared calculator result
+
+Exit criteria:
+
+1. ramming outcome rules are expressed in static data plus one pure calculator
+2. engine movement does not contain rule-specific ram tables
+
+### Phase 4: Schema-Ready Cleanup
+
+Deliverables:
+
+1. normalize any remaining rule shapes that still depend on engine-specific state objects
+2. document the canonical static rules bundle and its intended serialization boundary
+3. remove leftover compatibility shims if they are no longer needed
+
+Exit criteria:
+
+1. the static rules model is ready to move into external data files later without another major ownership refactor
+
+## TDD Plan
+
+The implementation should follow red-green-refactor in small slices.
+
+Recommended test order:
+
+1. add or update pure tests for shared rule queries first
+2. add or update pure tests for `shared/movePlanner.ts` consuming those queries
+3. add pure tests for the new shared ramming calculator
+4. then update engine movement tests and API tests to prove the engine is only adapting shared results
+
+## Actionable Checklist
+
+- [ ] Add focused red tests for rule-query helpers derived from canonical unit definitions
+- [x] Remove duplicated unit definitions from `server/engine/units.ts`
+- [x] Replace `MOVEMENT_PROFILES` with definition-derived movement queries
+- [x] Extract shared occupancy and stack rules out of `shared/movePlanner.ts`
+- [x] Update engine movement validation to use shared movement-rule queries
+- [ ] Add a pure shared ramming calculator and migrate engine movement to it
+- [ ] Document the final canonical static rules bundle and schema-ready boundary

--- a/docs/shared-rules-platform-refactor-spec.md
+++ b/docs/shared-rules-platform-refactor-spec.md
@@ -1,8 +1,8 @@
 # Shared Rules Platform Refactor Spec
 
-**Status: In Progress (April 2026)**
+**Status: Complete (April 2026)**
 
-Status: Phase 3 complete
+Status: Phase 4 complete
 Date: 2026-04-13
 Branch: `feature/shared-rules-platform-refactor`
 
@@ -109,6 +109,20 @@ Minimum shape:
 
 That bundle should be stable enough to serialize later, even if it is still authored in TypeScript for now.
 
+Canonical boundary:
+
+1. `shared/staticRules.ts` is the current bundle-of-record
+2. `ONION_STATIC_RULES` is the export consumers should depend on when they need canonical static gameplay rules
+3. the bundle currently includes unit definitions and terrain rules only
+4. future serialization work should transform this bundle, not rebuild equivalent rules from engine modules
+
+Serialization contract:
+
+1. static bundle content may describe unit stats, terrain interactions, stack limits, target restrictions, and ram profiles
+2. static bundle content must not include live game state such as positions, statuses, spent movement, or phase progression
+3. pure shared calculators may depend on the bundle directly
+4. engine modules should adapt live state into calculator inputs and apply outputs, but not redefine static rules
+
 ### Shared Movement Rules API
 
 Add a pure rules-query layer that owns questions like:
@@ -197,6 +211,8 @@ Exit criteria:
 
 ### Phase 4: Schema-Ready Cleanup
 
+Status: Complete on 2026-04-13
+
 Deliverables:
 
 1. normalize any remaining rule shapes that still depend on engine-specific state objects
@@ -226,4 +242,4 @@ Recommended test order:
 - [x] Extract shared occupancy and stack rules out of `shared/movePlanner.ts`
 - [x] Update engine movement validation to use shared movement-rule queries
 - [x] Add a pure shared ramming calculator and migrate engine movement to it
-- [ ] Document the final canonical static rules bundle and schema-ready boundary
+- [x] Document the final canonical static rules bundle and schema-ready boundary

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,6 +5,11 @@ break down into features/tasks as needed.
 
 ## In progress
 
+- [ ] Shared rules platform consolidation
+  - [ ] Externalize unit and weapon definitions so types, stats, and target rules can move to a shared data file or schema later.
+  - [x] Collapse the current split between movement profiles, pathfinding, and stacking rules so terrain entry, cover, and occupancy checks all come from the same unit/terrain definition model.
+  - [ ] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
+
 ## Epics / Major Work
 
 - [ ] Improve error handling (UI and backend)
@@ -17,7 +22,8 @@ break down into features/tasks as needed.
 
 ## Features / Work Items
 
-- [ ] Collapse the current split between movement profiles, pathfinding, and stacking rules so terrain entry, cover, and occupancy checks all come from the same unit/terrain definition model.
+- [ ] Consolidate shared pure tests under one directory and normalize aliases/import paths as part of that cleanup.
+- [ ] Normalize imports across all server code so shared and server modules use aliases consistently.
 - [ ] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
 
 ## Done

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,8 +5,8 @@ break down into features/tasks as needed.
 
 ## In progress
 
-- [ ] Shared rules platform consolidation
-  - [ ] Externalize unit and weapon definitions so types, stats, and target rules can move to a shared data file or schema later.
+- [x] Shared rules platform consolidation
+  - [x] Externalize unit and weapon definitions so types, stats, and target rules can move to a shared data file or schema later.
   - [x] Collapse the current split between movement profiles, pathfinding, and stacking rules so terrain entry, cover, and occupancy checks all come from the same unit/terrain definition model.
   - [x] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
 
@@ -18,7 +18,6 @@ break down into features/tasks as needed.
 - [ ] JWT authentication (migrate to @fastify/jwt)
 - [ ] Game lobby for creation and joining (self-service matchmaking)
 - [ ] Stacked unit management: UI and logic for selecting, splitting, and combining units in a stack; support for independent and combined moves and combat actions
-- [ ] Externalize unit and weapon definitions so types, stats, and target rules can move to a shared data file or schema later
 
 ## Features / Work Items
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -8,7 +8,7 @@ break down into features/tasks as needed.
 - [ ] Shared rules platform consolidation
   - [ ] Externalize unit and weapon definitions so types, stats, and target rules can move to a shared data file or schema later.
   - [x] Collapse the current split between movement profiles, pathfinding, and stacking rules so terrain entry, cover, and occupancy checks all come from the same unit/terrain definition model.
-  - [ ] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
+  - [x] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
 
 ## Epics / Major Work
 
@@ -24,7 +24,6 @@ break down into features/tasks as needed.
 
 - [ ] Consolidate shared pure tests under one directory and normalize aliases/import paths as part of that cleanup.
 - [ ] Normalize imports across all server code so shared and server modules use aliases consistently.
-- [ ] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
 
 ## Done
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -23,6 +23,10 @@ break down into features/tasks as needed.
 
 - [ ] Consolidate shared pure tests under one directory and normalize aliases/import paths as part of that cleanup.
 - [ ] Normalize imports across all server code so shared and server modules use aliases consistently.
+- [ ] Improve debug folding so protocol entries preserve full detail instead of collapsing the fetched response payloads.
+- [ ] Add more robust server-side logging that includes event details for MOVE and FIRE outcomes.
+- [ ] Add event-driven toasts for inactive players so the non-active client can surface actions taken by the other side (for example: MOVE ram results, combat outcomes, unit destruction, and phase changes).
+  - [ ] Define which events should trigger passive toasts, how they are deduplicated, and how they should appear when the player is not the active actor.
 
 ## Done
 

--- a/server/api/games.ts
+++ b/server/api/games.ts
@@ -266,18 +266,22 @@ function buildCombatEvents(
 
 function buildMoveEvents(
   startSeq: number,
+  moveUnitId: string,
   command: Extract<Command, { type: 'MOVE' }>,
   result: ReturnType<typeof executeUnitMovement>,
   state: any,
 ): EventEnvelope[] {
   const timestamp = new Date().toISOString()
   let seq = startSeq
+  const onionUnitId = state.onion.id
+  const canonicalMoveUnitId = moveUnitId
+  const isOnionMove = canonicalMoveUnitId === onionUnitId
   const events: EventEnvelope[] = [
     {
       seq: seq++,
-      type: command.unitId === 'onion' ? 'ONION_MOVED' : 'UNIT_MOVED',
+      type: isOnionMove ? 'ONION_MOVED' : 'UNIT_MOVED',
       timestamp,
-      ...(command.unitId === 'onion' ? { to: command.to } : { unitId: command.unitId, to: command.to }),
+      ...(isOnionMove ? { to: command.to } : { unitId: canonicalMoveUnitId, to: command.to }),
     },
   ]
 
@@ -288,7 +292,7 @@ function buildMoveEvents(
       seq: seq++,
       type: 'MOVE_RESOLVED',
       timestamp,
-      unitId: command.unitId,
+      unitId: canonicalMoveUnitId,
       rammedUnitIds,
       destroyedUnitIds,
       treadDamage: result.treadDamage ?? 0,
@@ -951,7 +955,7 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
         }
 
         const nextSeq = (match.events.at(-1)?.seq ?? 0) + 1
-        newEvents = buildMoveEvents(nextSeq, command, result, state)
+        newEvents = buildMoveEvents(nextSeq, validation.plan.unitId, command, result, state)
 
         currentState = state
         const winner = computeWinnerUserId(match, state, match.phase, match.turnNumber) ?? match.winner

--- a/server/api/games.ts
+++ b/server/api/games.ts
@@ -264,6 +264,61 @@ function buildCombatEvents(
   return events
 }
 
+function buildMoveEvents(
+  startSeq: number,
+  command: Extract<Command, { type: 'MOVE' }>,
+  result: ReturnType<typeof executeUnitMovement>,
+  state: any,
+): EventEnvelope[] {
+  const timestamp = new Date().toISOString()
+  let seq = startSeq
+  const events: EventEnvelope[] = [
+    {
+      seq: seq++,
+      type: command.unitId === 'onion' ? 'ONION_MOVED' : 'UNIT_MOVED',
+      timestamp,
+      ...(command.unitId === 'onion' ? { to: command.to } : { unitId: command.unitId, to: command.to }),
+    },
+  ]
+
+  const rammedUnitIds = result.rammedUnitIds ?? []
+  const destroyedUnitIds = result.destroyedUnits ?? []
+  if (rammedUnitIds.length > 0 || destroyedUnitIds.length > 0 || (result.treadDamage ?? 0) > 0) {
+    events.push({
+      seq: seq++,
+      type: 'MOVE_RESOLVED',
+      timestamp,
+      unitId: command.unitId,
+      rammedUnitIds,
+      destroyedUnitIds,
+      treadDamage: result.treadDamage ?? 0,
+    })
+  }
+
+  if (result.treadDamage !== undefined && result.treadDamage > 0) {
+    events.push({
+      seq: seq++,
+      type: 'ONION_TREADS_LOST',
+      timestamp,
+      amount: result.treadDamage,
+      remaining: state.onion.treads,
+    })
+  }
+
+  for (const destroyedId of destroyedUnitIds) {
+    events.push({
+      seq: seq++,
+      type: 'UNIT_STATUS_CHANGED',
+      timestamp,
+      unitId: destroyedId,
+      from: 'operational',
+      to: 'destroyed',
+    })
+  }
+
+  return events
+}
+
 function logSentEvents(gameId: number, actionType: string, events: EventEnvelope[]) {
   logger.debug(
     {
@@ -895,31 +950,8 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
           return reply.status(422).send({ ok: false, error: result.error, code: 'MOVE_INVALID', currentPhase: match.phase })
         }
 
-        const timestamp = new Date().toISOString()
-        let nextSeq = (match.events.at(-1)?.seq ?? 0) + 1
-        const eventType = command.unitId === 'onion' ? 'ONION_MOVED' : 'UNIT_MOVED'
-        newEvents = [{ seq: nextSeq++, type: eventType, timestamp, ...(command.unitId === 'onion' ? { to: command.to } : { unitId: command.unitId, to: command.to }) }]
-
-        if (result.treadDamage !== undefined && result.treadDamage > 0) {
-          newEvents.push({
-            seq: nextSeq++,
-            type: 'ONION_TREADS_LOST',
-            timestamp,
-            amount: result.treadDamage,
-            remaining: state.onion.treads,
-          })
-        }
-
-        for (const destroyedId of result.destroyedUnits ?? []) {
-          newEvents.push({
-            seq: nextSeq++,
-            type: 'UNIT_STATUS_CHANGED',
-            timestamp,
-            unitId: destroyedId,
-            from: 'operational',
-            to: 'destroyed',
-          })
-        }
+        const nextSeq = (match.events.at(-1)?.seq ?? 0) + 1
+        newEvents = buildMoveEvents(nextSeq, command, result, state)
 
         currentState = state
         const winner = computeWinnerUserId(match, state, match.phase, match.turnNumber) ?? match.winner

--- a/server/engine/combat.ts
+++ b/server/engine/combat.ts
@@ -13,11 +13,10 @@ import {
   createCombatCalculator,
   calculateOdds as sharedCalculateOdds,
   type CombatCalculatorInput,
-  type CombatStaticRules,
 } from '../../shared/combatCalculator.js'
+import { ONION_STATIC_RULES } from '../../shared/staticRules.js'
 import { isTargetAllowedByRules, resolveUnitTargetRules, resolveWeaponTargetRules } from '../../shared/targetRules.js'
 import { getReadyWeapons, getUnitDefense, getWeaponDefense, destroyWeapon } from './units.js'
-import { getAllUnitDefinitions } from './units.js'
 import type { GameUnit, OnionUnit, DefenderUnit, EngineGameState } from './units.js'
 
 /**
@@ -111,14 +110,7 @@ export interface CombatExecutionResult {
 
 type FireCommand = Extract<Command, { type: 'FIRE' }>
 
-const COMBAT_STATIC_RULES: CombatStaticRules = {
-  unitDefinitions: getAllUnitDefinitions(),
-  terrainRules: {
-    clear: { terrainType: 'clear' },
-    ridgeline: { terrainType: 'ridgeline', defenseBonus: 1 },
-    crater: { terrainType: 'crater' },
-  },
-}
+const COMBAT_STATIC_RULES = ONION_STATIC_RULES
 
 const combatCalculator = createCombatCalculator(COMBAT_STATIC_RULES)
 

--- a/server/engine/movement.ts
+++ b/server/engine/movement.ts
@@ -13,6 +13,7 @@ import { getUnitDefinition, isImmobile } from './units.js'
 import type { GameUnit, DefenderUnit, EngineGameState, OnionUnit } from './units.js'
 import { findMovePath, type MoveMapSnapshot } from '../../shared/movePlanner.js'
 import { getStopOnOccupiedHexFailure } from '../../shared/movementRules.js'
+import { calculateRamming as calculateSharedRamming } from '../../shared/rammingCalculator.js'
 import { canUnitCrossRidgelines, canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, spendUnitMovement } from '../../shared/unitMovement.js'
 
 /**
@@ -588,17 +589,7 @@ export function calculateRamming(rammedUnit: DefenderUnit, roll?: number): {
   treadCost: number
   destroyed: boolean
 } {
-  const def = getUnitDefinition(rammedUnit.type)
-  let treadCost: number
-  if (rammedUnit.type === 'LittlePigs') {
-    treadCost = 0
-  } else if (def.abilities.isArmor && rammedUnit.type === 'Dragon') {
-    treadCost = 2
-  } else {
-    treadCost = 1
-  }
-  const d6 = roll ?? (Math.floor(Math.random() * 6) + 1)
-  return { treadCost, destroyed: d6 <= 4 }
+  return calculateSharedRamming(rammedUnit.type, roll)
 }
 
 /**

--- a/server/engine/movement.ts
+++ b/server/engine/movement.ts
@@ -12,6 +12,7 @@ import type { GameMap } from './map.js'
 import { getUnitDefinition, isImmobile } from './units.js'
 import type { GameUnit, DefenderUnit, EngineGameState, OnionUnit } from './units.js'
 import { findMovePath, type MoveMapSnapshot } from '../../shared/movePlanner.js'
+import { getStopOnOccupiedHexFailure } from '../../shared/movementRules.js'
 import { canUnitCrossRidgelines, canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, spendUnitMovement } from '../../shared/unitMovement.js'
 
 /**
@@ -200,43 +201,51 @@ function validateDestinationStacking(
       unit.position.q === destination.q &&
       unit.position.r === destination.r,
   )
-
-  if (role === 'onion') {
-    if (defendersAtDestination.length > 0 && !capabilities.canRam) {
-      return { ok: false, code: 'HEX_OCCUPIED', error: 'Destination hex is occupied' }
-    }
-    return null
-  }
-
-  const onionOccupiesDestination =
-    state.onion.id !== movingUnit.id &&
+  const occupants = [
+    ...(state.onion.id !== movingUnit.id &&
     state.onion.status !== 'destroyed' &&
     state.onion.position.q === destination.q &&
     state.onion.position.r === destination.r
+      ? [{ q: destination.q, r: destination.r, role: 'onion' as const, unitType: state.onion.type, squads: 1 }]
+      : []),
+    ...defendersAtDestination.map((unit) => ({
+      q: unit.position.q,
+      r: unit.position.r,
+      role: 'defender' as const,
+      unitType: unit.type,
+      squads: unit.squads,
+    })),
+  ]
 
-  if (onionOccupiesDestination) {
-    return { ok: false, code: 'HEX_OCCUPIED', error: 'Destination hex is occupied by the Onion' }
-  }
-
-  if (movingUnit.type === 'LittlePigs') {
-    if (defendersAtDestination.some((unit) => unit.type !== 'LittlePigs')) {
-      return { ok: false, code: 'HEX_OCCUPIED', error: 'Little Pigs can only stack with other Little Pigs' }
-    }
-
-    const incomingSquads = movingUnit.squads ?? 1
-    const destinationSquads = defendersAtDestination.reduce((sum, unit) => sum + (unit.squads ?? 1), 0)
-    if (incomingSquads + destinationSquads > 3) {
-      return { ok: false, code: 'HEX_OCCUPIED', error: 'Little Pigs stack limit is 3 squads per hex' }
-    }
-
-    return null
-  }
-
-  if (defendersAtDestination.length > 0) {
+  if (role === 'onion' && occupants.length > 0 && !capabilities.canRam) {
     return { ok: false, code: 'HEX_OCCUPIED', error: 'Destination hex is occupied' }
   }
 
-  return null
+  const failure = getStopOnOccupiedHexFailure({
+    movingRole: role,
+    movingUnitType: movingUnit.type,
+    occupants,
+    incomingSquads: movingUnit.squads ?? 1,
+  })
+
+  if (failure === null) {
+    return null
+  }
+
+  if (failure === 'occupied-by-onion') {
+    return { ok: false, code: 'HEX_OCCUPIED', error: 'Destination hex is occupied by the Onion' }
+  }
+
+  if (failure === 'mixed-stack') {
+    return { ok: false, code: 'HEX_OCCUPIED', error: 'Little Pigs can only stack with other Little Pigs' }
+  }
+
+  if (failure === 'stack-limit') {
+    const maxStacks = getUnitDefinition(movingUnit.type).abilities.maxStacks
+    return { ok: false, code: 'HEX_OCCUPIED', error: `Little Pigs stack limit is ${maxStacks} squads per hex` }
+  }
+
+  return { ok: false, code: 'HEX_OCCUPIED', error: 'Destination hex is occupied' }
 }
 
 function validateMovePlan(

--- a/server/engine/movement.ts
+++ b/server/engine/movement.ts
@@ -15,6 +15,7 @@ import { findMovePath, type MoveMapSnapshot } from '../../shared/movePlanner.js'
 import { getStopOnOccupiedHexFailure } from '../../shared/movementRules.js'
 import { calculateRamming as calculateSharedRamming } from '../../shared/rammingCalculator.js'
 import { canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, spendUnitMovement } from '../../shared/unitMovement.js'
+import { canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, getUnitRamCapacity, spendUnitMovement } from '../../shared/unitMovement.js'
 
 /**
  * Result of validating a movement command.
@@ -294,12 +295,13 @@ function validateMovePlan(
 
   const rammedUnits = capabilities.canRam ? collectPathOccupants(state, pathResult.path, unit.id) : []
   const ramCapacityUsed = rammedUnits.length
+  const ramCapacityLimit = getUnitRamCapacity(unit.type)
 
-  if (capabilities.canRam && state.ramsThisTurn + ramCapacityUsed > 2) {
+  if (capabilities.canRam && state.ramsThisTurn + ramCapacityUsed > ramCapacityLimit) {
     return {
       ok: false,
       code: 'RAM_LIMIT_EXCEEDED',
-      error: `Would exceed ram limit (${state.ramsThisTurn} used, ${ramCapacityUsed} on path)`,
+      error: `Would exceed ram limit (${state.ramsThisTurn} used, ${ramCapacityUsed} on path, limit ${ramCapacityLimit})`,
     }
   }
 

--- a/server/engine/movement.ts
+++ b/server/engine/movement.ts
@@ -14,7 +14,7 @@ import type { GameUnit, DefenderUnit, EngineGameState, OnionUnit } from './units
 import { findMovePath, type MoveMapSnapshot } from '../../shared/movePlanner.js'
 import { getStopOnOccupiedHexFailure } from '../../shared/movementRules.js'
 import { calculateRamming as calculateSharedRamming } from '../../shared/rammingCalculator.js'
-import { canUnitCrossRidgelines, canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, spendUnitMovement } from '../../shared/unitMovement.js'
+import { canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, spendUnitMovement } from '../../shared/unitMovement.js'
 
 /**
  * Result of validating a movement command.

--- a/server/engine/movement.ts
+++ b/server/engine/movement.ts
@@ -34,7 +34,6 @@ export interface MovementCapabilities {
   canRam: boolean
   hasTreads: boolean
   canSecondMove: boolean
-  canCrossRidgelines: boolean
 }
 
 export interface MovementPlan {
@@ -113,7 +112,6 @@ function getCapabilities(unit: GameUnit): MovementCapabilities {
     canRam: getUnitDefinition(unit.type).abilities.canRam === true,
     hasTreads: hasTreads(unit),
     canSecondMove: canUnitSecondMove(unit.type),
-    canCrossRidgelines: canUnitCrossRidgelines(unit.type),
   }
 }
 
@@ -283,7 +281,6 @@ function validateMovePlan(
     from: unit.position,
     to: command.to,
     movementAllowance: allowance.movementAllowance,
-    canCrossRidgelines: capabilities.canCrossRidgelines,
     movingRole: role,
     movingUnitType: unit.type,
   })

--- a/server/engine/units.ts
+++ b/server/engine/units.ts
@@ -7,7 +7,7 @@ import type { UnitDefinition, UnitType } from '../../shared/engineTypes.js'
 import { getAllUnitDefinitions as getSharedUnitDefinitions } from '../../shared/unitDefinitions.js'
 import logger from '../logger.js'
 import { onionMovementAllowance } from '../../shared/movementAllowance.js'
-export type { RamProfile, UnitAbilities, UnitTerrainRule, WeaponStatus } from '../../shared/engineTypes.js'
+export type { RamProfile, UnitAbilities, UnitTerrainRule, UnitDefinition, UnitType, WeaponStatus } from '../../shared/engineTypes.js'
 export type { Weapon } from '../../shared/types/index.js'
 
 /**

--- a/server/engine/units.ts
+++ b/server/engine/units.ts
@@ -54,7 +54,7 @@ export interface EngineGameState {
   onion: OnionUnit
   /** All defender units, keyed by unit ID */
   defenders: Record<string, DefenderUnit>
-  /** Number of rams the Onion has performed this turn (max 2) */
+  /** Number of rams the Onion has performed this turn */
   ramsThisTurn: number
   /** Movement already spent this turn, keyed by phase and unit ID */
   movementSpent?: Record<string, number>

--- a/server/engine/units.ts
+++ b/server/engine/units.ts
@@ -1,126 +1,14 @@
 /**
  * Unit definitions and capabilities for the Onion game engine.
- *
- * Defines all unit types, their weapons, special abilities, and game mechanics.
  */
 
-import type { HexPos, UnitStatus, TurnPhase } from '../../shared/types/index.js'
-import type { TargetRules } from '../../shared/targetRules.js'
+import type { HexPos, UnitStatus, TurnPhase, Weapon, TargetRules } from '../../shared/types/index.js'
+import type { UnitDefinition, UnitType } from '../../shared/engineTypes.js'
+import { getAllUnitDefinitions as getSharedUnitDefinitions } from '../../shared/unitDefinitions.js'
 import logger from '../logger.js'
 import { onionMovementAllowance } from '../../shared/movementAllowance.js'
-
-/**
- * All possible unit types in the game.
- */
-export type UnitType =
-  | 'TheOnion'      // Super-unit with multiple weapon systems
-  | 'BigBadWolf'    // GEV - can move and fire in same turn
-  | 'Puss'          // Heavy Tank
-  | 'Witch'         // Missile Tank
-  | 'LordFarquaad'  // Howitzer - immobile artillery
-  | 'Pinocchio'     // Light Tank
-  | 'Dragon'        // Superheavy Tank
-  | 'LittlePigs'    // Infantry - can stack multiple squads
-  | 'Castle'        // Command Post - primary objective
-
-/**
- * Status that a weapon can have.
- */
-export type WeaponStatus = 'ready' | 'spent' | 'destroyed'
-
-/**
- * A weapon system that a unit can use to attack.
- */
-export interface Weapon {
-  /** Weapon identifier (e.g., 'main', 'secondary', 'ap', 'missile') */
-  id: string
-  /** Display name */
-  name: string
-  /** Attack strength */
-  attack: number
-  /** Range in hexes (0 for melee-only) */
-  range: number
-  /** Defense value when this weapon is targeted */
-  defense: number
-  /** Current status of this weapon */
-  status: WeaponStatus
-  /** Whether this weapon can be individually targeted (true for Onion subsystems) */
-  individuallyTargetable: boolean
-  /** Optional target restrictions for this weapon. */
-  targetRules?: TargetRules
-}
-
-/**
- * Special abilities that units can have.
- */
-export interface UnitTerrainRule {
-  /** Whether the unit can enter or cross this terrain feature. */
-  canCross?: boolean
-  /** Whether the unit can benefit from this terrain's defense cover. */
-  canAccessCover?: boolean
-  /** Whether the unit ignores underlying terrain while on this feature. */
-  ignoresUnderlyingTerrain?: boolean
-}
-
-/**
- * Structured outcome for ram resolution against a unit.
- */
-export interface RamProfile {
-  /** Result category when rammed. */
-  outcome: 'destroyed' | 'disabled' | 'tread-loss' | 'special'
-  /** Tread cost applied to the ramming unit when outcome is tread-loss. */
-  treadLoss?: 0 | 1 | 2 | 3
-  /** Inclusive die range for a disabled outcome. */
-  disableRollRange?: [number, number]
-  /** Freeform note for exceptional cases such as special attack resolution. */
-  specialNote?: string
-}
-
-/**
- * Special abilities that units can have.
- */
-export interface UnitAbilities {
-  /** Can move and fire in the same turn (GEV) */
-  secondMove?: boolean
-  /** Movement allowance for the GEV second-move phase (hexes) */
-  secondMoveAllowance?: number
-  /** Can move through enemy units and ram them */
-  canRam?: boolean
-  /** Per-terrain capability rules for movement and cover. */
-  terrainRules?: Record<string, UnitTerrainRule>
-  /** Structured ramming outcome for this unit when it is rammed. */
-  ramProfile?: RamProfile
-  /** Maximum stacks per hex (1 for most units, 3 for infantry) */
-  maxStacks: number
-  /** Can cross ridgelines (Onion) */
-  canCrossRidgelines?: boolean
-  /** Is an armored unit (affects ramming costs) */
-  isArmor?: boolean
-  /** Immobile once placed (artillery) - for code readability */
-  immobile?: boolean
-}
-
-/**
- * Complete unit definition combining weapons and abilities.
- */
-export interface UnitDefinition {
-  /** Display name */
-  name: string
-  /** Unit type identifier */
-  type: UnitType
-  /** Movement allowance in hexes */
-  movement: number
-  /** Base defense rating (for infantry: defense per squad) */
-  defense: number
-  /** Cost in victory points (for defender units) */
-  cost?: number
-  /** Special abilities */
-  abilities: UnitAbilities
-  /** Weapon systems */
-  weapons: Weapon[]
-  /** Optional target restrictions for this unit. */
-  targetRules?: TargetRules
-}
+export type { RamProfile, UnitAbilities, UnitTerrainRule, WeaponStatus } from '../../shared/engineTypes.js'
+export type { Weapon } from '../../shared/types/index.js'
 
 /**
  * A game unit with current state.
@@ -197,7 +85,7 @@ export function getUnitDefinition(type: UnitType | string): UnitDefinition | und
  * @returns Map of unit type to definition
  */
 export function getAllUnitDefinitions(): Record<UnitType, UnitDefinition> {
-  return { ...UNIT_DEFINITIONS }
+  return getSharedUnitDefinitions()
 }
 
 export { onionMovementAllowance }
@@ -296,136 +184,4 @@ export function destroyWeapon(unit: GameUnit, weaponId: string): boolean {
 
 // ─── Unit Definitions ────────────────────────────────────────────────────────
 
-function makeWeapon(
-  id: string,
-  name: string,
-  attack: number,
-  range: number,
-  defense: number,
-  individuallyTargetable = false,
-  targetRules?: TargetRules
-): Weapon {
-  return { id, name, attack, range, defense, status: 'ready', individuallyTargetable, targetRules }
-}
-
-const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
-  Puss: {
-    name: 'Puss',
-    type: 'Puss',
-    movement: 3,
-    defense: 3,
-    cost: 1,
-    abilities: { maxStacks: 1, isArmor: true },
-    weapons: [makeWeapon('main', 'Main Gun', 4, 2, 3)],
-  },
-
-  BigBadWolf: {
-    name: 'Big Bad Wolf',
-    type: 'BigBadWolf',
-    movement: 4,
-    defense: 4,
-    cost: 1,
-    abilities: { maxStacks: 1, isArmor: true, secondMove: true, secondMoveAllowance: 3 },
-    weapons: [makeWeapon('main', 'Cannon', 2, 2, 4)],
-  },
-
-  Witch: {
-    name: 'Witch',
-    type: 'Witch',
-    movement: 2,
-    defense: 2,
-    cost: 1,
-    abilities: { maxStacks: 1, isArmor: true },
-    weapons: [makeWeapon('main', 'Missile Launcher', 3, 4, 2)],
-  },
-
-  LordFarquaad: {
-    name: 'Lord Farquaad',
-    type: 'LordFarquaad',
-    movement: 0,
-    defense: 0,
-    cost: 2,
-    abilities: { maxStacks: 1, immobile: true },
-    weapons: [makeWeapon('main', 'Howitzer', 6, 8, 0)],
-  },
-
-  Pinocchio: {
-    name: 'Pinocchio',
-    type: 'Pinocchio',
-    movement: 2,
-    defense: 3,
-    cost: 0.5,
-    abilities: { maxStacks: 1, isArmor: true },
-    weapons: [makeWeapon('main', 'Light Gun', 2, 2, 3)],
-  },
-
-  Dragon: {
-    name: 'Dragon',
-    type: 'Dragon',
-    movement: 5,
-    defense: 3,
-    cost: 2,
-    abilities: { maxStacks: 1, isArmor: true },
-    weapons: [
-      makeWeapon('main_1', 'Heavy Gun A', 6, 3, 3),
-      makeWeapon('main_2', 'Heavy Gun B', 6, 3, 3),
-    ],
-  },
-
-  LittlePigs: {
-    name: 'Little Pigs',
-    type: 'LittlePigs',
-    movement: 1,
-    defense: 1,     // per squad; getUnitDefense multiplies by unit.squads
-    cost: 1,        // per 3 squads
-    abilities: {
-      maxStacks: 3,
-      canCrossRidgelines: true,
-      terrainRules: {
-        ridgeline: { canCross: true, canAccessCover: true },
-      },
-    },
-    weapons: [makeWeapon('rifle', 'Rifle', 1, 1, 1)],
-  },
-
-  Castle: {
-    name: 'Castle',
-    type: 'Castle',
-    movement: 0,
-    defense: 0,
-    abilities: { maxStacks: 1 },
-    weapons: [],
-  },
-
-  TheOnion: {
-    name: 'The Onion',
-    type: 'TheOnion',
-    movement: 3,    // max MA (at 31–45 treads); onionMovementAllowance() gives actual MA
-    defense: 0,     // Onion has no unit-level defense; each subsystem has its own
-    abilities: {
-      maxStacks: 1,
-      canCrossRidgelines: true,
-      canRam: true,
-      terrainRules: {
-        ridgeline: { canCross: true },
-      },
-    },
-    weapons: [
-      makeWeapon('main', 'Main Battery', 4, 3, 4, true),
-      makeWeapon('secondary_1', 'Secondary Battery', 3, 2, 3, true),
-      makeWeapon('secondary_2', 'Secondary Battery', 3, 2, 3, true),
-      makeWeapon('secondary_3', 'Secondary Battery', 3, 2, 3, true),
-      makeWeapon('secondary_4', 'Secondary Battery', 3, 2, 3, true),
-      makeWeapon('ap_1', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
-      makeWeapon('ap_2', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
-      makeWeapon('ap_3', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
-      makeWeapon('ap_4', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
-      makeWeapon('ap_5', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
-      makeWeapon('ap_6', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
-      makeWeapon('ap_7', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
-      makeWeapon('ap_8', 'AP Gun', 1, 1, 1, true, { allowedTargetUnitTypes: ['LittlePigs', 'Castle'] }),
-      makeWeapon('missile_1', 'Missile', 6, 5, 3, true),
-      makeWeapon('missile_2', 'Missile', 6, 5, 3, true),
-    ],
-  },
-}
+const UNIT_DEFINITIONS = getSharedUnitDefinitions()

--- a/shared/engineTypes.ts
+++ b/shared/engineTypes.ts
@@ -22,10 +22,8 @@ export interface UnitTerrainRule {
 }
 
 export interface RamProfile {
-  outcome: 'destroyed' | 'disabled' | 'tread-loss' | 'special'
   treadLoss?: 0 | 1 | 2 | 3
-  disableRollRange?: [number, number]
-  specialNote?: string
+  destroyOnRollAtMost?: number
 }
 
 export interface UnitAbilities {

--- a/shared/engineTypes.ts
+++ b/shared/engineTypes.ts
@@ -30,6 +30,7 @@ export interface UnitAbilities {
   secondMove?: boolean
   secondMoveAllowance?: number
   canRam?: boolean
+  ramCapacity?: number
   terrainRules?: Record<string, UnitTerrainRule>
   ramProfile?: RamProfile
   maxStacks: number

--- a/shared/engineTypes.ts
+++ b/shared/engineTypes.ts
@@ -33,7 +33,6 @@ export interface UnitAbilities {
   terrainRules?: Record<string, UnitTerrainRule>
   ramProfile?: RamProfile
   maxStacks: number
-  canCrossRidgelines?: boolean
   isArmor?: boolean
   immobile?: boolean
 }

--- a/shared/movePlanner.ts
+++ b/shared/movePlanner.ts
@@ -1,4 +1,11 @@
 import { getNeighbors, hexKey, type HexPos } from './hex.js'
+import {
+	canStopOnOccupiedHex,
+	canTraverseOccupiedHex,
+	getTerrainMoveCost,
+	type MoveOccupant,
+	type MoveRole,
+} from './movementRules.js'
 
 export type MoveMapSnapshot = {
 	width: number
@@ -22,9 +29,7 @@ export type ReachableMove = {
 
 type TerrainType = 'clear' | 'ridgeline' | 'crater'
 
-type MoveRole = 'onion' | 'defender'
-
-type Occupant = NonNullable<MoveMapSnapshot['occupiedHexes']>[number]
+type Occupant = MoveOccupant
 
 function terrainFromT(t: number): TerrainType {
 	if (t === 1) return 'ridgeline'
@@ -57,45 +62,6 @@ function getOccupiedLookup(map: MoveMapSnapshot): Map<string, Occupant[]> {
 	return lookup
 }
 
-function canTraverseOccupiedHex(movingRole: MoveRole, occupants: Occupant[]): boolean {
-	if (occupants.length === 0) {
-		return true
-	}
-
-	if (movingRole === 'onion') {
-		return occupants.some((occupant) => occupant.role === 'defender')
-	}
-
-	return occupants.every((occupant) => occupant.role === 'defender')
-}
-
-function canStopOnOccupiedHex(
-	movingRole: MoveRole,
-	movingUnitType: string,
-	occupants: Occupant[],
-	incomingSquads: number = 1
-): boolean {
-	if (occupants.length === 0) {
-		return true
-	}
-
-	if (movingRole === 'onion') {
-		return occupants.every((occupant) => occupant.role === 'defender')
-	}
-
-	const isLittlePigs = movingUnitType === 'LittlePigs'
-	if (!isLittlePigs) {
-		return false
-	}
-
-	if (!occupants.every((occupant) => occupant.role === 'defender' && occupant.unitType === 'LittlePigs')) {
-		return false
-	}
-
-	const destinationSquads = occupants.reduce((total, occupant) => total + (occupant.squads ?? 1), 0)
-	return incomingSquads + destinationSquads <= 3
-}
-
 function reconstructPath(prev: Map<string, HexPos | null>, from: HexPos, to: HexPos): HexPos[] {
 	const path: HexPos[] = []
 	let cursor: HexPos | null = to
@@ -112,7 +78,7 @@ function exploreReachableMoves(
 	map: MoveMapSnapshot,
 	from: HexPos,
 	movementAllowance: number,
-	canCrossRidgelines: boolean,
+	movingUnitType: string,
 	movingRole: MoveRole,
 ) {
 	const terrainLookup = getTerrainLookup(map)
@@ -135,7 +101,7 @@ function exploreReachableMoves(
 			if (!canTraverseOccupiedHex(movingRole, neighborOccupants)) continue
 
 			const terrain = terrainLookup.get(hexKey(neighbor)) ?? 'clear'
-			const stepCost = terrainCost(terrain, canCrossRidgelines)
+			const stepCost = getTerrainMoveCost(movingUnitType, terrain)
 			if (stepCost === null) continue
 
 			const newCost = cost + stepCost
@@ -190,12 +156,12 @@ export function findMovePath(input: {
 		if (
 			pos.q === input.to.q &&
 			pos.r === input.to.r &&
-			canStopOnOccupiedHex(
-				input.movingRole,
-				input.movingUnitType,
-				currentOccupants,
-				input.incomingSquads ?? 1
-			)
+			canStopOnOccupiedHex({
+				movingRole: input.movingRole,
+				movingUnitType: input.movingUnitType,
+				occupants: currentOccupants,
+				incomingSquads: input.incomingSquads ?? 1,
+			})
 		) {
 			return { found: true, path: reconstructPath(prev, input.from, input.to), cost }
 		}
@@ -206,7 +172,7 @@ export function findMovePath(input: {
 			if (!canTraverseOccupiedHex(input.movingRole, neighborOccupants)) continue
 
 			const terrain = terrainLookup.get(hexKey(neighbor)) ?? 'clear'
-			const stepCost = terrainCost(terrain, input.canCrossRidgelines)
+			const stepCost = getTerrainMoveCost(input.movingUnitType, terrain)
 			if (stepCost === null) continue
 
 			const newCost = cost + stepCost
@@ -233,7 +199,7 @@ export function listReachableMoves(input: {
 	movingUnitType: string
 	incomingSquads?: number
 }): ReachableMove[] {
-	const { dist, prev } = exploreReachableMoves(input.map, input.from, input.movementAllowance, input.canCrossRidgelines, input.movingRole)
+	const { dist, prev } = exploreReachableMoves(input.map, input.from, input.movementAllowance, input.movingUnitType, input.movingRole)
 	const occupiedLookup = getOccupiedLookup(input.map)
 
 	const moves: ReachableMove[] = []
@@ -243,7 +209,12 @@ export function listReachableMoves(input: {
 		const [q, r] = key.split(',').map(Number)
 		const to = { q, r }
 		const occupants = occupiedLookup.get(key) ?? []
-		if (!canStopOnOccupiedHex(input.movingRole, input.movingUnitType, occupants, input.incomingSquads ?? 1)) {
+		if (!canStopOnOccupiedHex({
+			movingRole: input.movingRole,
+			movingUnitType: input.movingUnitType,
+			occupants,
+			incomingSquads: input.incomingSquads ?? 1,
+		})) {
 			continue
 		}
 		moves.push({

--- a/shared/movePlanner.ts
+++ b/shared/movePlanner.ts
@@ -37,12 +37,6 @@ function terrainFromT(t: number): TerrainType {
 	return 'clear'
 }
 
-function terrainCost(terrain: TerrainType, canCrossRidgelines: boolean): number | null {
-	if (terrain === 'crater') return null
-	if (terrain === 'ridgeline') return canCrossRidgelines ? 2 : null
-	return 1
-}
-
 function getCellLookup(map: MoveMapSnapshot): Set<string> {
 	return new Set(map.cells.map(hexKey))
 }
@@ -124,7 +118,6 @@ export function findMovePath(input: {
 	from: HexPos
 	to: HexPos
 	movementAllowance: number
-	canCrossRidgelines: boolean
 	movingRole: MoveRole
 	movingUnitType: string
 	incomingSquads?: number
@@ -194,7 +187,6 @@ export function listReachableMoves(input: {
 	map: MoveMapSnapshot
 	from: HexPos
 	movementAllowance: number
-	canCrossRidgelines: boolean
 	movingRole: MoveRole
 	movingUnitType: string
 	incomingSquads?: number

--- a/shared/movementRules.ts
+++ b/shared/movementRules.ts
@@ -1,0 +1,108 @@
+import type { TerrainType, UnitDefinition } from './engineTypes.js'
+import { getAllUnitDefinitions } from './unitDefinitions.js'
+
+export type MoveRole = 'onion' | 'defender'
+
+export type MoveOccupant = {
+	q: number
+	r: number
+	role: MoveRole
+	unitType: string
+	squads?: number
+}
+
+export type StopOccupationFailure =
+	| 'occupied-by-onion'
+	| 'occupied'
+	| 'mixed-stack'
+	| 'stack-limit'
+
+const UNIT_DEFINITIONS = getAllUnitDefinitions()
+
+function getUnitDefinition(unitType: string): UnitDefinition | undefined {
+	return UNIT_DEFINITIONS[unitType as keyof typeof UNIT_DEFINITIONS]
+}
+
+export function canUnitCrossRidgeline(unitType: string): boolean {
+	const definition = getUnitDefinition(unitType)
+	if (definition === undefined) {
+		return false
+	}
+
+	return definition.abilities.terrainRules?.ridgeline?.canCross === true || definition.abilities.canCrossRidgelines === true
+}
+
+export function canUnitAccessTerrainCover(unitType: string, terrainType: TerrainType): boolean {
+	const definition = getUnitDefinition(unitType)
+	if (definition === undefined) {
+		return false
+	}
+
+	return definition.abilities.terrainRules?.[terrainType]?.canAccessCover === true
+}
+
+export function getTerrainMoveCost(unitType: string, terrainType: TerrainType): number | null {
+	if (terrainType === 'crater') {
+		return null
+	}
+
+	if (terrainType === 'ridgeline') {
+		return canUnitCrossRidgeline(unitType) ? 2 : null
+	}
+
+	return 1
+}
+
+export function canTraverseOccupiedHex(movingRole: MoveRole, occupants: MoveOccupant[]): boolean {
+	if (occupants.length === 0) {
+		return true
+	}
+
+	if (movingRole === 'onion') {
+		return occupants.some((occupant) => occupant.role === 'defender')
+	}
+
+	return occupants.every((occupant) => occupant.role === 'defender')
+}
+
+export function getStopOnOccupiedHexFailure(input: {
+	movingRole: MoveRole
+	movingUnitType: string
+	occupants: MoveOccupant[]
+	incomingSquads?: number
+}): StopOccupationFailure | null {
+	const { movingRole, movingUnitType, occupants, incomingSquads = 1 } = input
+
+	if (occupants.length === 0) {
+		return null
+	}
+
+	if (movingRole === 'onion') {
+		return occupants.every((occupant) => occupant.role === 'defender') ? null : 'occupied'
+	}
+
+	if (occupants.some((occupant) => occupant.role === 'onion')) {
+		return 'occupied-by-onion'
+	}
+
+	if (movingUnitType !== 'LittlePigs') {
+		return 'occupied'
+	}
+
+	if (!occupants.every((occupant) => occupant.role === 'defender' && occupant.unitType === 'LittlePigs')) {
+		return 'mixed-stack'
+	}
+
+	const maxStacks = getUnitDefinition(movingUnitType)?.abilities.maxStacks ?? 1
+	const destinationSquads = occupants.reduce((total, occupant) => total + (occupant.squads ?? 1), 0)
+	return incomingSquads + destinationSquads <= maxStacks ? null : 'stack-limit'
+}
+
+export function canStopOnOccupiedHex(input: {
+	movingRole: MoveRole
+	movingUnitType: string
+	occupants: MoveOccupant[]
+	incomingSquads?: number
+}): boolean {
+	return getStopOnOccupiedHexFailure(input) === null
+}

--- a/shared/movementRules.ts
+++ b/shared/movementRules.ts
@@ -29,7 +29,7 @@ export function canUnitCrossRidgeline(unitType: string): boolean {
 		return false
 	}
 
-	return definition.abilities.terrainRules?.ridgeline?.canCross === true || definition.abilities.canCrossRidgelines === true
+	return definition.abilities.terrainRules?.ridgeline?.canCross === true
 }
 
 export function canUnitAccessTerrainCover(unitType: string, terrainType: TerrainType): boolean {

--- a/shared/rammingCalculator.ts
+++ b/shared/rammingCalculator.ts
@@ -1,0 +1,23 @@
+import { getAllUnitDefinitions } from './unitDefinitions.js'
+
+export type RammingResult = {
+	treadCost: number
+	destroyed: boolean
+}
+
+const UNIT_DEFINITIONS = getAllUnitDefinitions()
+
+export function calculateRamming(unitType: string, roll?: number): RammingResult {
+	const definition = UNIT_DEFINITIONS[unitType as keyof typeof UNIT_DEFINITIONS]
+	const ramProfile = definition?.abilities.ramProfile
+
+	if (definition === undefined || ramProfile === undefined) {
+		throw new Error(`Unit type '${unitType}' does not define a ram profile`)
+	}
+
+	const d6 = roll ?? (Math.floor(Math.random() * 6) + 1)
+	return {
+		treadCost: ramProfile.treadLoss ?? 0,
+		destroyed: d6 <= (ramProfile.destroyOnRollAtMost ?? 0),
+	}
+}

--- a/shared/staticRules.ts
+++ b/shared/staticRules.ts
@@ -1,0 +1,18 @@
+import type { TerrainType } from './engineTypes.js'
+import type { CombatStaticRules, CombatTerrainRule } from './combatCalculator.js'
+import { getAllUnitDefinitions } from './unitDefinitions.js'
+
+const TERRAIN_RULES: Readonly<Record<TerrainType, CombatTerrainRule>> = {
+	clear: { terrainType: 'clear' },
+	ridgeline: { terrainType: 'ridgeline', defenseBonus: 1 },
+	crater: { terrainType: 'crater' },
+}
+
+export const ONION_STATIC_RULES: CombatStaticRules = {
+	unitDefinitions: getAllUnitDefinitions(),
+	terrainRules: TERRAIN_RULES,
+}
+
+export function getStaticRules(): CombatStaticRules {
+	return ONION_STATIC_RULES
+}

--- a/shared/unitDefinitions.ts
+++ b/shared/unitDefinitions.ts
@@ -20,7 +20,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     movement: 3,
     defense: 3,
     cost: 1,
-    abilities: { maxStacks: 1, isArmor: true },
+    abilities: { maxStacks: 1, isArmor: true, ramProfile: { treadLoss: 1, destroyOnRollAtMost: 4 } },
     weapons: [makeWeapon('main', 'Main Gun', 4, 2, 3)],
   },
   BigBadWolf: {
@@ -29,7 +29,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     movement: 4,
     defense: 4,
     cost: 1,
-    abilities: { maxStacks: 1, isArmor: true, secondMove: true, secondMoveAllowance: 3 },
+    abilities: { maxStacks: 1, isArmor: true, secondMove: true, secondMoveAllowance: 3, ramProfile: { treadLoss: 1, destroyOnRollAtMost: 4 } },
     weapons: [makeWeapon('main', 'Cannon', 2, 2, 4)],
   },
   Witch: {
@@ -38,7 +38,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     movement: 2,
     defense: 2,
     cost: 1,
-    abilities: { maxStacks: 1, isArmor: true },
+    abilities: { maxStacks: 1, isArmor: true, ramProfile: { treadLoss: 1, destroyOnRollAtMost: 4 } },
     weapons: [makeWeapon('main', 'Missile Launcher', 3, 4, 2)],
   },
   LordFarquaad: {
@@ -47,7 +47,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     movement: 0,
     defense: 0,
     cost: 2,
-    abilities: { maxStacks: 1, immobile: true },
+    abilities: { maxStacks: 1, immobile: true, ramProfile: { treadLoss: 1, destroyOnRollAtMost: 4 } },
     weapons: [makeWeapon('main', 'Howitzer', 6, 8, 0)],
   },
   Pinocchio: {
@@ -56,7 +56,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     movement: 2,
     defense: 3,
     cost: 0.5,
-    abilities: { maxStacks: 1, isArmor: true },
+    abilities: { maxStacks: 1, isArmor: true, ramProfile: { treadLoss: 1, destroyOnRollAtMost: 4 } },
     weapons: [makeWeapon('main', 'Light Gun', 2, 2, 3)],
   },
   Dragon: {
@@ -65,7 +65,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     movement: 5,
     defense: 3,
     cost: 2,
-    abilities: { maxStacks: 1, isArmor: true },
+    abilities: { maxStacks: 1, isArmor: true, ramProfile: { treadLoss: 2, destroyOnRollAtMost: 4 } },
     weapons: [
       makeWeapon('main_1', 'Heavy Gun A', 6, 3, 3),
       makeWeapon('main_2', 'Heavy Gun B', 6, 3, 3),
@@ -80,6 +80,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     abilities: {
       maxStacks: 3,
       canCrossRidgelines: true,
+      ramProfile: { treadLoss: 0, destroyOnRollAtMost: 4 },
       terrainRules: {
         ridgeline: { canCross: true, canAccessCover: true },
       },
@@ -91,7 +92,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     type: 'Castle',
     movement: 0,
     defense: 0,
-    abilities: { maxStacks: 1 },
+    abilities: { maxStacks: 1, ramProfile: { treadLoss: 1, destroyOnRollAtMost: 4 } },
     weapons: [],
   },
   TheOnion: {

--- a/shared/unitDefinitions.ts
+++ b/shared/unitDefinitions.ts
@@ -79,7 +79,6 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     cost: 1,
     abilities: {
       maxStacks: 3,
-      canCrossRidgelines: true,
       ramProfile: { treadLoss: 0, destroyOnRollAtMost: 4 },
       terrainRules: {
         ridgeline: { canCross: true, canAccessCover: true },
@@ -102,7 +101,6 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     defense: 0,
     abilities: {
       maxStacks: 1,
-      canCrossRidgelines: true,
       canRam: true,
       terrainRules: {
         ridgeline: { canCross: true },

--- a/shared/unitDefinitions.ts
+++ b/shared/unitDefinitions.ts
@@ -102,6 +102,7 @@ const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     abilities: {
       maxStacks: 1,
       canRam: true,
+      ramCapacity: 2,
       terrainRules: {
         ridgeline: { canCross: true },
       },

--- a/shared/unitMovement.ts
+++ b/shared/unitMovement.ts
@@ -1,28 +1,12 @@
 import type { TurnPhase } from './types/index.js'
 import { onionMovementAllowance } from './movementAllowance.js'
+import { getAllUnitDefinitions } from './unitDefinitions.js'
+import { canUnitCrossRidgeline } from './movementRules.js'
 
-type MovementProfile = {
-	movement: number
-	canCrossRidgelines?: boolean
-	secondMoveAllowance?: number
-	secondMove?: boolean
-	immobile?: boolean
-}
+const UNIT_DEFINITIONS = getAllUnitDefinitions()
 
-const MOVEMENT_PROFILES: Record<string, MovementProfile> = {
-	TheOnion: { movement: 3, canCrossRidgelines: true },
-	BigBadWolf: { movement: 4, secondMoveAllowance: 3, secondMove: true },
-	Puss: { movement: 3 },
-	Witch: { movement: 2 },
-	LordFarquaad: { movement: 0, immobile: true },
-	Pinocchio: { movement: 2 },
-	Dragon: { movement: 5 },
-	LittlePigs: { movement: 1, canCrossRidgelines: true },
-	Castle: { movement: 0, immobile: true },
-}
-
-function getProfile(unitType: string): MovementProfile {
-	return MOVEMENT_PROFILES[unitType] ?? { movement: 0 }
+function getDefinition(unitType: string) {
+	return UNIT_DEFINITIONS[unitType as keyof typeof UNIT_DEFINITIONS]
 }
 
 function movementSpentKey(phase: TurnPhase, unitId: string): string {
@@ -30,19 +14,19 @@ function movementSpentKey(phase: TurnPhase, unitId: string): string {
 }
 
 export function canUnitCrossRidgelines(unitType: string): boolean {
-	return getProfile(unitType).canCrossRidgelines === true
+	return canUnitCrossRidgeline(unitType)
 }
 
 export function canUnitSecondMove(unitType: string): boolean {
-	return getProfile(unitType).secondMove === true
+	return getDefinition(unitType)?.abilities.secondMove === true
 }
 
 export function isUnitImmobile(unitType: string): boolean {
-	return getProfile(unitType).immobile === true
+	return getDefinition(unitType)?.abilities.immobile === true
 }
 
 export function getUnitMovementAllowance(unitType: string, phase: TurnPhase, treads?: number): number {
-	const profile = getProfile(unitType)
+	const definition = getDefinition(unitType)
 
 	if (unitType === 'TheOnion') {
 		if (phase !== 'ONION_MOVE') {
@@ -53,14 +37,14 @@ export function getUnitMovementAllowance(unitType: string, phase: TurnPhase, tre
 	}
 
 	if (phase === 'GEV_SECOND_MOVE') {
-		return canUnitSecondMove(unitType) ? profile.secondMoveAllowance ?? 0 : 0
+		return canUnitSecondMove(unitType) ? definition?.abilities.secondMoveAllowance ?? 0 : 0
 	}
 
 	if (phase !== 'DEFENDER_MOVE') {
 		return 0
 	}
 
-	return profile.movement
+	return definition?.movement ?? 0
 }
 
 type MovementSpentState = {

--- a/shared/unitMovement.ts
+++ b/shared/unitMovement.ts
@@ -17,6 +17,10 @@ export function canUnitCrossRidgelines(unitType: string): boolean {
 	return canUnitCrossRidgeline(unitType)
 }
 
+export function getUnitRamCapacity(unitType: string): number {
+	return getDefinition(unitType)?.abilities.ramCapacity ?? 2
+}
+
 export function canUnitSecondMove(unitType: string): boolean {
 	return getDefinition(unitType)?.abilities.secondMove === true
 }

--- a/src/test/lib/engine/movement.test.ts
+++ b/src/test/lib/engine/movement.test.ts
@@ -243,6 +243,17 @@ describe('validateUnitMovement', () => {
     expect(result.plan.capabilities.hasTreads).toBe(true)
   })
 
+  it('rejects the legacy onion alias when the actual Onion id differs', () => {
+    const state = makeState({ onion: makeOnion({ id: 'onion-1' }) })
+    const result = validateUnitMovement(CLEAR_MAP, state, { type: 'MOVE', unitId: 'onion', to: { q: 2, r: 0 } })
+
+    expect(result).toEqual({
+      ok: false,
+      code: 'UNIT_NOT_FOUND',
+      error: "Unit 'onion' not found",
+    })
+  })
+
   it('allows Onion to move into an occupied defender destination as a ram', () => {
     const defender = makeDefender({ id: 'd1', position: { q: 1, r: 0 } })
     const state = makeState({ defenders: { d1: defender } })

--- a/test/server/api/games.actions.move.test.ts
+++ b/test/server/api/games.actions.move.test.ts
@@ -31,8 +31,16 @@ describe('POST /games/:id/actions MOVE', () => {
     const { gameId } = await createGame(app, shrek.token, 'onion')
     await joinGame(app, gameId, fiona.token)
 
+    const initialStateRes = await app.inject({
+      method: 'GET',
+      url: `/games/${gameId}`,
+      headers: { authorization: `Bearer ${shrek.token}` },
+    })
+    const initialStateBody = initialStateRes.json<{ state: { onion: { id?: string; position: { q: number; r: number } } } }>()
+    const onionUnitId = initialStateBody.state.onion.id ?? 'onion-1'
+
     const moveTo = { q: 1, r: 10 }
-    const validatedPlan = createMovePlan({ to: moveTo, path: [moveTo] })
+    const validatedPlan = createMovePlan({ unitId: onionUnitId, from: initialStateBody.state.onion.position, to: moveTo, path: [moveTo] })
     const validateSpy = vi.spyOn(engineGame, 'validateUnitMovement').mockReturnValue({ ok: true, plan: validatedPlan } as any)
     const executeSpy = vi.spyOn(engineGame, 'executeUnitMovement').mockImplementation(((state: any, plan: any) => {
       state.onion.position = plan.to
@@ -43,7 +51,7 @@ describe('POST /games/:id/actions MOVE', () => {
       method: 'POST',
       url: `/games/${gameId}/actions`,
       headers: { authorization: `Bearer ${shrek.token}` },
-      payload: { type: 'MOVE', unitId: 'onion', to: moveTo },
+      payload: { type: 'MOVE', unitId: onionUnitId, to: moveTo },
     })
 
     expect(res.statusCode).toBe(200)
@@ -233,8 +241,16 @@ describe('POST /games/:id/actions MOVE', () => {
     const { gameId } = await createGame(app, shrek.token, 'onion')
     await joinGame(app, gameId, fiona.token)
 
+    const initialStateRes = await app.inject({
+      method: 'GET',
+      url: `/games/${gameId}`,
+      headers: { authorization: `Bearer ${shrek.token}` },
+    })
+    const initialStateBody = initialStateRes.json<{ state: { onion: { id?: string; position: { q: number; r: number } } } }>()
+    const onionUnitId = initialStateBody.state.onion.id ?? 'onion-1'
+
     const moveTo = { q: 1, r: 10 }
-    const validatedPlan = createMovePlan({ to: moveTo, path: [moveTo], rammedUnitIds: ['d1'], ramCapacityUsed: 1, treadCost: 1 })
+    const validatedPlan = createMovePlan({ unitId: onionUnitId, from: initialStateBody.state.onion.position, to: moveTo, path: [moveTo], rammedUnitIds: ['d1'], ramCapacityUsed: 1, treadCost: 1 })
     const validateSpy = vi.spyOn(engineGame, 'validateUnitMovement').mockReturnValue({ ok: true, plan: validatedPlan } as any)
     const executeSpy = vi.spyOn(engineGame, 'executeUnitMovement').mockImplementation(((state: any, plan: any) => {
       state.onion.position = plan.to
@@ -253,7 +269,7 @@ describe('POST /games/:id/actions MOVE', () => {
       method: 'POST',
       url: `/games/${gameId}/actions`,
       headers: { authorization: `Bearer ${shrek.token}` },
-      payload: { type: 'MOVE', unitId: 'onion', to: moveTo },
+      payload: { type: 'MOVE', unitId: onionUnitId, to: moveTo },
     })
 
     validateSpy.mockRestore()
@@ -290,8 +306,16 @@ describe('POST /games/:id/actions MOVE', () => {
     const { gameId } = await createGame(app, shrek.token, 'onion')
     await joinGame(app, gameId, fiona.token)
 
+    const initialStateRes = await app.inject({
+      method: 'GET',
+      url: `/games/${gameId}`,
+      headers: { authorization: `Bearer ${shrek.token}` },
+    })
+    const initialStateBody = initialStateRes.json<{ state: { onion: { id?: string; position: { q: number; r: number } } } }>()
+    const onionUnitId = initialStateBody.state.onion.id ?? 'onion-1'
+
     const moveTo = { q: 1, r: 10 }
-    const validatedPlan = createMovePlan({ to: moveTo, path: [moveTo], rammedUnitIds: ['d1'], ramCapacityUsed: 1, treadCost: 1 })
+    const validatedPlan = createMovePlan({ unitId: onionUnitId, from: initialStateBody.state.onion.position, to: moveTo, path: [moveTo], rammedUnitIds: ['d1'], ramCapacityUsed: 1, treadCost: 1 })
     const validateSpy = vi.spyOn(engineGame, 'validateUnitMovement').mockReturnValue({ ok: true, plan: validatedPlan } as any)
     const executeSpy = vi.spyOn(engineGame, 'executeUnitMovement').mockImplementation(((state: any, plan: any) => {
       state.onion.position = plan.to
@@ -310,7 +334,7 @@ describe('POST /games/:id/actions MOVE', () => {
       method: 'POST',
       url: `/games/${gameId}/actions`,
       headers: { authorization: `Bearer ${shrek.token}` },
-      payload: { type: 'MOVE', unitId: 'onion', to: moveTo },
+      payload: { type: 'MOVE', unitId: onionUnitId, to: moveTo },
     })
 
     validateSpy.mockRestore()

--- a/test/server/api/games.actions.move.test.ts
+++ b/test/server/api/games.actions.move.test.ts
@@ -226,7 +226,7 @@ describe('POST /games/:id/actions MOVE', () => {
     expect(body.winner).toBe('defender')
   })
 
-  it('emits ONION_TREADS_LOST and UNIT_STATUS_CHANGED events when a ram destroys a unit', async () => {
+  it('emits MOVE_RESOLVED, ONION_TREADS_LOST and UNIT_STATUS_CHANGED events when a ram destroys a unit', async () => {
     const app = buildApp()
     const shrek = await register(app, 'shrek')
     const fiona = await register(app, 'fiona')
@@ -265,8 +265,14 @@ describe('POST /games/:id/actions MOVE', () => {
 
     const eventTypes = body.events.map((e: any) => e.type)
     expect(eventTypes[0]).toBe('ONION_MOVED')
+    expect(eventTypes[1]).toBe('MOVE_RESOLVED')
     expect(eventTypes).toContain('ONION_TREADS_LOST')
     expect(eventTypes).toContain('UNIT_STATUS_CHANGED')
+
+    const ramEvent = body.events.find((e: any) => e.type === 'MOVE_RESOLVED')
+    expect(ramEvent.rammedUnitIds).toEqual(['d1'])
+    expect(ramEvent.destroyedUnitIds).toEqual(['d1'])
+    expect(ramEvent.treadDamage).toBe(1)
 
     const treadEvent = body.events.find((e: any) => e.type === 'ONION_TREADS_LOST')
     expect(treadEvent.amount).toBe(1)
@@ -277,7 +283,7 @@ describe('POST /games/:id/actions MOVE', () => {
     expect(statusEvent.to).toBe('destroyed')
   })
 
-  it('emits only ONION_TREADS_LOST (no UNIT_STATUS_CHANGED) when ram does not destroy the unit', async () => {
+  it('emits MOVE_RESOLVED and ONION_TREADS_LOST (no UNIT_STATUS_CHANGED) when ram does not destroy the unit', async () => {
     const app = buildApp()
     const shrek = await register(app, 'shrek')
     const fiona = await register(app, 'fiona')
@@ -316,8 +322,14 @@ describe('POST /games/:id/actions MOVE', () => {
 
     const eventTypes = body.events.map((e: any) => e.type)
     expect(eventTypes[0]).toBe('ONION_MOVED')
+    expect(eventTypes[1]).toBe('MOVE_RESOLVED')
     expect(eventTypes).toContain('ONION_TREADS_LOST')
     expect(eventTypes).not.toContain('UNIT_STATUS_CHANGED')
+
+    const ramEvent = body.events.find((e: any) => e.type === 'MOVE_RESOLVED')
+    expect(ramEvent.rammedUnitIds).toEqual(['d1'])
+    expect(ramEvent.destroyedUnitIds).toEqual([])
+    expect(ramEvent.treadDamage).toBe(1)
 
     const treadEvent = body.events.find((e: any) => e.type === 'ONION_TREADS_LOST')
     expect(treadEvent.amount).toBe(1)

--- a/test/server/api/helpers.ts
+++ b/test/server/api/helpers.ts
@@ -162,7 +162,6 @@ export function createMovePlan(overrides: Partial<Record<string, unknown>> = {})
       canRam: true,
       hasTreads: true,
       canSecondMove: false,
-      canCrossRidgelines: true,
     },
     ...overrides,
   }

--- a/test/server/api/integration.helpers.ts
+++ b/test/server/api/integration.helpers.ts
@@ -117,17 +117,6 @@ function movementAllowanceFor(state: any, unitId: string): number {
   return definition?.movement ?? 0
 }
 
-function canCrossRidgelines(state: any, unitId: string): boolean {
-  if (unitId === state.onion.id) {
-    return true
-  }
-
-  const unit = state.defenders[unitId]
-  if (!unit) return false
-  const definition = getUnitDefinition(unit.type)
-  return definition?.abilities.canCrossRidgelines === true
-}
-
 function buildMoveMapSnapshot(map: ScenarioMap, state: any, unitId: string): MoveMapSnapshot {
   const occupiedHexes: NonNullable<MoveMapSnapshot['occupiedHexes']> = [
     ...(state.onion.id !== unitId
@@ -176,7 +165,6 @@ export function chooseReachableMoveToward(
     map: moveMap,
     from: unit.position,
     movementAllowance,
-    canCrossRidgelines: canCrossRidgelines(state, unitId),
     movingRole: unitId === state.onion.id ? 'onion' : 'defender',
     movingUnitType: unit.type,
     incomingSquads: unit.squads,

--- a/test/server/lib/engine/movement.test.ts
+++ b/test/server/lib/engine/movement.test.ts
@@ -397,7 +397,6 @@ describe('executeUnitMovement', () => {
         canRam: false,
         hasTreads: false,
         canSecondMove: false,
-        canCrossRidgelines: false,
       },
       ...overrides,
     }
@@ -428,7 +427,6 @@ describe('executeUnitMovement', () => {
         canRam: true,
         hasTreads: true,
         canSecondMove: false,
-        canCrossRidgelines: true,
       },
     })
 

--- a/test/server/lib/engine/units.test.ts
+++ b/test/server/lib/engine/units.test.ts
@@ -255,7 +255,7 @@ describe('getUnitDefinition', () => {
 
   describe('LittlePigs (Infantry)', () => {
     it('can cross ridgelines', () => {
-      expect(getUnitDefinition('LittlePigs').abilities.canCrossRidgelines).toBe(true)
+	  expect(getUnitDefinition('LittlePigs').abilities.terrainRules?.ridgeline?.canCross).toBe(true)
     })
 
     it('has maxStacks of 3', () => {

--- a/test/server/lib/engine/units.test.ts
+++ b/test/server/lib/engine/units.test.ts
@@ -16,6 +16,7 @@ import {
   canTargetWeapon,
   destroyWeapon,
 } from '#server/engine/units'
+import { getAllUnitDefinitions as getSharedUnitDefinitions } from '#shared/unitDefinitions'
 // ─── Logger Mocking ─────────────────────────────────────────────────────────
 vi.mock('#server/logger', () => ({
   default: {
@@ -375,6 +376,18 @@ describe('getAllUnitDefinitions', () => {
     for (const [key, def] of Object.entries(all)) {
       expect(def.type).toBe(key)
     }
+  })
+
+  it('mirrors the canonical shared definition source', () => {
+    expect(getAllUnitDefinitions()).toEqual(getSharedUnitDefinitions())
+  })
+
+  it('includes ram profiles in the shared definition source for rammed units', () => {
+    const shared = getSharedUnitDefinitions()
+
+    expect(shared.LittlePigs.abilities.ramProfile).toEqual({ treadLoss: 0, destroyOnRollAtMost: 4 })
+    expect(shared.Puss.abilities.ramProfile).toEqual({ treadLoss: 1, destroyOnRollAtMost: 4 })
+    expect(shared.Dragon.abilities.ramProfile).toEqual({ treadLoss: 2, destroyOnRollAtMost: 4 })
   })
 })
 

--- a/test/server/lib/pure/movePlanner.test.ts
+++ b/test/server/lib/pure/movePlanner.test.ts
@@ -78,7 +78,7 @@ describe('movePlanner', () => {
 			movementAllowance: 2,
 			canCrossRidgelines: true,
 			movingRole: 'defender',
-			movingUnitType: 'Puss',
+			movingUnitType: 'LittlePigs',
 		})
 
 		expect(result).toEqual({

--- a/test/server/lib/pure/movePlanner.test.ts
+++ b/test/server/lib/pure/movePlanner.test.ts
@@ -40,7 +40,6 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			to: { q: 2, r: 1 },
 			movementAllowance: 1,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})
@@ -58,7 +57,6 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			to: { q: 0, r: 2 },
 			movementAllowance: 1,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})
@@ -76,7 +74,6 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			to: { q: 2, r: 1 },
 			movementAllowance: 2,
-			canCrossRidgelines: true,
 			movingRole: 'defender',
 			movingUnitType: 'LittlePigs',
 		})
@@ -94,7 +91,6 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			to: { q: 2, r: 2 },
 			movementAllowance: 3,
-			canCrossRidgelines: true,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})
@@ -115,7 +111,6 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			to: { q: 3, r: 1 },
 			movementAllowance: 3,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})
@@ -136,7 +131,6 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			to: { q: 2, r: 1 },
 			movementAllowance: 1,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})
@@ -157,7 +151,6 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			to: { q: 2, r: 1 },
 			movementAllowance: 1,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'LittlePigs',
 		})
@@ -178,7 +171,6 @@ describe('movePlanner', () => {
 			from: { q: 1, r: 1 },
 			to: { q: 3, r: 1 },
 			movementAllowance: 3,
-			canCrossRidgelines: false,
 			movingRole: 'onion',
 			movingUnitType: 'TheOnion',
 		})
@@ -195,7 +187,6 @@ describe('movePlanner', () => {
 			map: clearMap,
 			from: { q: 1, r: 1 },
 			movementAllowance: 1,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})
@@ -214,7 +205,6 @@ describe('movePlanner', () => {
 			map: terrainMap,
 			from: { q: 1, r: 1 },
 			movementAllowance: 1,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})
@@ -231,7 +221,6 @@ describe('movePlanner', () => {
 			},
 			from: { q: 1, r: 1 },
 			movementAllowance: 3,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})
@@ -249,7 +238,6 @@ describe('movePlanner', () => {
 			},
 			from: { q: 1, r: 1 },
 			movementAllowance: 2,
-			canCrossRidgelines: false,
 			movingRole: 'defender',
 			movingUnitType: 'Puss',
 		})

--- a/test/server/lib/pure/movementRules.test.ts
+++ b/test/server/lib/pure/movementRules.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	canStopOnOccupiedHex,
+	canTraverseOccupiedHex,
+	getTerrainMoveCost,
+	type MoveOccupant,
+} from '#shared/movementRules'
+
+function occupant(overrides: Partial<MoveOccupant> = {}): MoveOccupant {
+	return {
+		q: 0,
+		r: 0,
+		role: 'defender',
+		unitType: 'Puss',
+		squads: 1,
+		...overrides,
+	}
+}
+
+describe('movementRules', () => {
+	it('derives ridgeline movement cost from shared terrain rules', () => {
+		expect(getTerrainMoveCost('Puss', 'ridgeline')).toBeNull()
+		expect(getTerrainMoveCost('LittlePigs', 'ridgeline')).toBe(2)
+		expect(getTerrainMoveCost('TheOnion', 'ridgeline')).toBe(2)
+	})
+
+	it('treats crater terrain as impassable', () => {
+		expect(getTerrainMoveCost('Puss', 'crater')).toBeNull()
+		expect(getTerrainMoveCost('TheOnion', 'crater')).toBeNull()
+	})
+
+	it('allows defenders to traverse only friendly occupied hexes', () => {
+		expect(canTraverseOccupiedHex('defender', [occupant({ role: 'defender' })])).toBe(true)
+		expect(canTraverseOccupiedHex('defender', [occupant({ role: 'onion', unitType: 'TheOnion' })])).toBe(false)
+	})
+
+	it('allows the Onion to traverse only defender-occupied hexes', () => {
+		expect(canTraverseOccupiedHex('onion', [occupant({ role: 'defender' })])).toBe(true)
+		expect(canTraverseOccupiedHex('onion', [occupant({ role: 'onion', unitType: 'TheOnion' })])).toBe(false)
+	})
+
+	it('allows Little Pigs to stop on a shared stack up to the rule-defined limit', () => {
+		expect(
+			canStopOnOccupiedHex({
+				movingRole: 'defender',
+				movingUnitType: 'LittlePigs',
+				occupants: [occupant({ unitType: 'LittlePigs', squads: 1 })],
+				incomingSquads: 2,
+			}),
+		).toBe(true)
+
+		expect(
+			canStopOnOccupiedHex({
+				movingRole: 'defender',
+				movingUnitType: 'LittlePigs',
+				occupants: [occupant({ unitType: 'LittlePigs', squads: 2 })],
+				incomingSquads: 2,
+			}),
+		).toBe(false)
+	})
+
+	it('rejects mixed or non-Little-Pigs defender stacks', () => {
+		expect(
+			canStopOnOccupiedHex({
+				movingRole: 'defender',
+				movingUnitType: 'LittlePigs',
+				occupants: [occupant({ unitType: 'Dragon' })],
+				incomingSquads: 1,
+			}),
+		).toBe(false)
+
+		expect(
+			canStopOnOccupiedHex({
+				movingRole: 'defender',
+				movingUnitType: 'Puss',
+				occupants: [occupant({ unitType: 'LittlePigs', squads: 1 })],
+			}),
+		).toBe(false)
+	})
+})

--- a/test/server/lib/pure/rammingCalculator.test.ts
+++ b/test/server/lib/pure/rammingCalculator.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateRamming } from '#shared/rammingCalculator'
+
+describe('rammingCalculator', () => {
+	it('uses the shared ram profile for Little Pigs', () => {
+		expect(calculateRamming('LittlePigs', 1)).toEqual({ treadCost: 0, destroyed: true })
+		expect(calculateRamming('LittlePigs', 5)).toEqual({ treadCost: 0, destroyed: false })
+	})
+
+	it('uses the shared ram profile for standard armored units', () => {
+		expect(calculateRamming('Puss', 4)).toEqual({ treadCost: 1, destroyed: true })
+		expect(calculateRamming('Witch', 6)).toEqual({ treadCost: 1, destroyed: false })
+	})
+
+	it('uses the heavier tread-loss profile for Dragon', () => {
+		expect(calculateRamming('Dragon', 4)).toEqual({ treadCost: 2, destroyed: true })
+		expect(calculateRamming('Dragon', 6)).toEqual({ treadCost: 2, destroyed: false })
+	})
+
+	it('throws when the unit type has no ram profile', () => {
+		expect(() => calculateRamming('TheOnion', 4)).toThrow(/ram profile/i)
+	})
+})

--- a/test/server/lib/pure/staticRules.test.ts
+++ b/test/server/lib/pure/staticRules.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { ONION_STATIC_RULES } from '#shared/staticRules'
+
+describe('staticRules bundle', () => {
+	it('exposes the canonical unit and terrain rules bundle', () => {
+		expect(ONION_STATIC_RULES.unitDefinitions.Puss.type).toBe('Puss')
+		expect(ONION_STATIC_RULES.terrainRules.ridgeline.defenseBonus).toBe(1)
+		expect(ONION_STATIC_RULES.terrainRules.crater.terrainType).toBe('crater')
+	})
+
+	it('keeps shared calculators on the same static unit definition source', () => {
+		expect(ONION_STATIC_RULES.unitDefinitions.TheOnion.abilities.canRam).toBe(true)
+		expect(ONION_STATIC_RULES.unitDefinitions.LittlePigs.abilities.ramProfile?.treadLoss).toBe(0)
+	})
+})

--- a/test/server/lib/pure/unitMovement.test.ts
+++ b/test/server/lib/pure/unitMovement.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { canUnitCrossRidgelines, canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, isUnitImmobile, spendUnitMovement } from '#shared/unitMovement'
+import { canUnitCrossRidgelines, canUnitSecondMove, getRemainingUnitMovementAllowance, getUnitMovementAllowance, getUnitRamCapacity, isUnitImmobile, spendUnitMovement } from '#shared/unitMovement'
 
 describe('unit movement helpers', () => {
 	it('returns Onion movement allowance by tread band during the movement phase', () => {
@@ -32,6 +32,7 @@ describe('unit movement helpers', () => {
 		expect(canUnitCrossRidgelines('TheOnion')).toBe(true)
 		expect(canUnitCrossRidgelines('LittlePigs')).toBe(true)
 		expect(canUnitCrossRidgelines('Puss')).toBe(false)
+		expect(getUnitRamCapacity('TheOnion')).toBe(2)
 		expect(isUnitImmobile('LordFarquaad')).toBe(true)
 		expect(isUnitImmobile('Puss')).toBe(false)
 	})

--- a/test/web/app/ui/App.ui.test.tsx
+++ b/test/web/app/ui/App.ui.test.tsx
@@ -277,6 +277,27 @@ describe('App UI', () => {
 		expect(document.querySelectorAll('.hex-cell-reachable').length).toBe(0)
 	})
 
+	it('shows remaining ram capacity in the Onion rail', async () => {
+		const snapshot = {
+			...createOnionMoveSnapshot('onion-1', 4),
+			authoritativeState: {
+				...createOnionMoveSnapshot('onion-1', 4).authoritativeState,
+				ramsThisTurn: 1,
+			},
+		}
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session: { role: 'onion' as const } }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} />)
+
+		const onionCard = await screen.findByRole('button', { name: /onion-1/i })
+		expect(onionCard.textContent).toContain('Rams remaining 1')
+		expect(screen.getByText((_, element) => element?.tagName === 'DT' && element?.textContent === 'Rams remaining')).not.toBeNull()
+	})
+
 	it('loads initial state under StrictMode', async () => {
 		const snapshot = createLoadedBattlefieldSnapshot()
 		const client = createGameClient({
@@ -363,6 +384,49 @@ describe('App UI', () => {
 		expect(jsonPrintText).toContain('(redacted)')
 		expect(jsonPrintText).toContain('player-1')
 		expect(jsonPrintText).toContain('username')
+	})
+
+	it('shows a ram resolution toast after a successful MOVE with ramming', async () => {
+		const user = userEvent.setup()
+		const snapshot = createOnionMoveSnapshot('onion-1', 4)
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session: { role: 'onion' as const } }),
+			submitAction: vi.fn().mockResolvedValue({
+				...snapshot,
+				authoritativeState: {
+					...snapshot.authoritativeState,
+					defenders: {
+						...snapshot.authoritativeState.defenders,
+						'puss-1': {
+							...snapshot.authoritativeState.defenders['puss-1'],
+							status: 'operational',
+						},
+					},
+				},
+				ramResolution: {
+					actionType: 'MOVE',
+					unitId: 'onion-1',
+					rammedUnitIds: ['puss-1'],
+					destroyedUnitIds: [],
+					treadDamage: 1,
+					details: ['Rammed units: puss-1', 'Treads lost: 1 (remaining 32)'],
+				},
+			}),
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} />)
+
+		await screen.findByTestId('hex-unit-onion-1')
+		await user.click(screen.getByTestId('hex-unit-onion-1'))
+		await act(async () => {
+			fireEvent.contextMenu(screen.getByTestId('hex-cell-0-2'))
+		})
+
+		expect(await screen.findByTestId('ram-resolution-toast')).not.toBeNull()
+		expect(screen.getByText(/Ram result/i)).not.toBeNull()
+		expect(screen.getByRole('heading', { name: /Ram resolved: target survived, Onion lost 1 tread/i })).not.toBeNull()
+		expect(screen.getByText(/Rammed units: puss-1/i)).not.toBeNull()
 	})
 
 	it('preserves debug popup position and size when toggled closed and reopened', async () => {

--- a/test/web/lib/pure/moveResolution.test.ts
+++ b/test/web/lib/pure/moveResolution.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatRamResolutionTitle } from '#web/lib/moveResolution'
+
+describe('formatRamResolutionTitle', () => {
+	it('describes the surviving target and tread loss explicitly', () => {
+		expect(
+			formatRamResolutionTitle({
+				actionType: 'MOVE',
+				unitId: 'onion-1',
+				rammedUnitIds: ['puss-1'],
+				destroyedUnitIds: [],
+				treadDamage: 1,
+				details: [],
+			}),
+		).toBe('Ram resolved: target survived, Onion lost 1 tread')
+	})
+
+	it('describes a destructive ram explicitly', () => {
+		expect(
+			formatRamResolutionTitle({
+				actionType: 'MOVE',
+				unitId: 'onion-1',
+				rammedUnitIds: ['puss-1'],
+				destroyedUnitIds: ['puss-1'],
+				treadDamage: 1,
+				details: [],
+			}),
+		).toBe('Ram resolved: 1 destroyed, Onion lost 1 tread')
+	})
+})

--- a/test/web/lib/transport/httpGameClient.adapter.contract.test.ts
+++ b/test/web/lib/transport/httpGameClient.adapter.contract.test.ts
@@ -295,12 +295,14 @@ describe('http game client adapter contract', () => {
 				ok: true,
 				seq: 48,
 				events: [
-					{ seq: 48, type: 'UNIT_MOVED', timestamp: '2026-03-26T12:00:00.000Z', unitId: 'wolf-2', to: { q: 7, r: 6 } },
+					{ seq: 48, type: 'MOVE_RESOLVED', timestamp: '2026-03-26T12:00:00.000Z', unitId: 'onion-1', rammedUnitIds: ['d1'], destroyedUnitIds: ['d1'], treadDamage: 1 },
+					{ seq: 49, type: 'ONION_TREADS_LOST', timestamp: '2026-03-26T12:00:00.000Z', amount: 1, remaining: 44 },
+					{ seq: 50, type: 'UNIT_STATUS_CHANGED', timestamp: '2026-03-26T12:00:00.000Z', unitId: 'd1', from: 'operational', to: 'destroyed' },
 				],
 				state: { onion: { position: { q: 0, r: 0 }, treads: 45 }, defenders: {} },
 				movementRemainingByUnit: { 'wolf-2': 3 },
 				turnNumber: 8,
-				eventSeq: 48,
+				eventSeq: 50,
 			}))
 
 		const client = createHttpGameClient({
@@ -310,12 +312,20 @@ describe('http game client adapter contract', () => {
 		})
 
 		await client.getState(123)
-		await expect(client.submitAction(123, { type: 'MOVE', unitId: 'wolf-2', to: { q: 7, r: 6 } })).resolves.toEqual(
+		await expect(client.submitAction(123, { type: 'MOVE', unitId: 'onion', to: { q: 7, r: 6 } })).resolves.toEqual(
 			expect.objectContaining({
 				gameId: 123,
 				phase: 'DEFENDER_MOVE',
-				lastEventSeq: 48,
+				lastEventSeq: 50,
 				movementRemainingByUnit: { 'wolf-2': 3 },
+				ramResolution: {
+					actionType: 'MOVE',
+					unitId: 'onion-1',
+					rammedUnitIds: ['d1'],
+					destroyedUnitIds: ['d1'],
+					treadDamage: 1,
+					details: ['Rammed units: d1', 'Treads lost: 1 (remaining 44)', 'Destroyed unit: d1 operational → destroyed'],
+				},
 			}),
 		)
 
@@ -327,7 +337,7 @@ describe('http game client adapter contract', () => {
 					authorization: 'Bearer stub.token',
 					'content-type': 'application/json',
 				}),
-				body: JSON.stringify({ type: 'MOVE', unitId: 'wolf-2', to: { q: 7, r: 6 } }),
+				body: JSON.stringify({ type: 'MOVE', unitId: 'onion', to: { q: 7, r: 6 } }),
 			}),
 		)
 	})

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -4,6 +4,7 @@ import ReactJsonPrintImport from 'react-json-print'
 import { HexMapBoard } from './components/HexMapBoard'
 import { CombatConfirmationView } from './components/CombatConfirmationView'
 import { CombatResolutionToast } from './components/CombatResolutionToast'
+import { MoveResolutionToast } from './components/MoveResolutionToast'
 import {
   GameClientSeamError,
   type GameAction,
@@ -23,6 +24,7 @@ import { buildCombatTargetOptions } from './lib/combatPreview'
 import type { WebRuntimeConfig } from './lib/appBootstrap'
 import { createHttpGameRequestTransport } from './lib/httpGameClient'
 import { createLiveEventSource } from './lib/liveEventSource'
+import { formatRamResolutionTitle } from './lib/moveResolution'
 import { useGameSession } from './lib/useGameSession'
 import {
   getApiProtocolTrafficSnapshot,
@@ -120,7 +122,7 @@ function ErrorOverlay({
   message: string
   onDismiss: () => void
   className?: string
-  placement?: 'corner' | 'map'
+  placement?: 'corner' | 'map' | 'app'
 }) {
   return (
     <div
@@ -374,6 +376,8 @@ function buildLiveOnion(snapshot: GameSnapshot, activePhase: TurnPhase | null): 
   const movementRemainingByUnit = snapshot.movementRemainingByUnit ?? {}
   const movesAllowed = activePhase === null ? 0 : getUnitMovementAllowance('TheOnion', activePhase, onion.treads)
   const movesRemaining = activePhase === null ? 0 : movementRemainingByUnit[onion.id ?? 'onion-1'] ?? movesAllowed
+  const ramCapacity = 2
+  const ramsRemaining = Math.max(ramCapacity - (authoritativeState.ramsThisTurn ?? 0), 0)
 
   return {
     id: onion.id ?? 'onion-1',
@@ -384,7 +388,7 @@ function buildLiveOnion(snapshot: GameSnapshot, activePhase: TurnPhase | null): 
     treads: onion.treads,
     movesAllowed,
     movesRemaining,
-    rams: authoritativeState.ramsThisTurn ?? 0,
+    rams: ramsRemaining,
     weapons: formatWeaponSummary(onion.weapons),
     weaponDetails: onion.weapons ?? [],
     targetRules: onion.targetRules,
@@ -640,6 +644,7 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
     const [actionError, setActionError] = useState<string | null>(null)
     const [, setPendingCombatSnapshot] = useState<GameSnapshot | null>(null)
     const [pendingCombatResolution, setPendingCombatResolution] = useState<GameSnapshot['combatResolution'] | null>(null)
+    const [pendingRamResolution, setPendingRamResolution] = useState<GameSnapshot['ramResolution'] | null>(null)
     const [combatBaseSnapshot, setCombatBaseSnapshot] = useState<GameSnapshot | null>(null)
     const [connectedSession, setConnectedSession] = useState<SessionBinding | null>(null)
     const [connectError, setConnectError] = useState<string | null>(null)
@@ -757,12 +762,13 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
         setCombatBaseSnapshot(previousSnapshot)
         setPendingCombatSnapshot(nextSnapshot)
         setPendingCombatResolution(nextSnapshot.combatResolution)
-        return
+      } else {
+        setCombatBaseSnapshot(null)
+        setPendingCombatSnapshot(null)
+        setPendingCombatResolution(null)
       }
 
-      setCombatBaseSnapshot(null)
-      setPendingCombatSnapshot(null)
-      setPendingCombatResolution(null)
+      setPendingRamResolution(nextSnapshot?.ramResolution ?? null)
       if (nextSnapshot !== null && !isCombatSnapshotPhase(nextSnapshot.phase)) {
         setSelectedCombatTargetId(null)
       }
@@ -796,6 +802,7 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
     setCombatBaseSnapshot(null)
     setPendingCombatSnapshot(null)
     setPendingCombatResolution(null)
+    setPendingRamResolution(null)
 
     if (clearSelection) {
       setSelectedUnitIds([])
@@ -805,6 +812,10 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
 
   function handleDismissCombatResolution() {
     clearPendingCombatResolution(true)
+  }
+
+  function handleDismissRamResolution() {
+    setPendingRamResolution(null)
   }
 
   function handleConfirmCombat() {
@@ -912,18 +923,8 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
     }
 
     setActionError(null)
-    try {
-      await activeSessionController.submitAction({ type: 'MOVE', unitId, to })
-      setSelectedUnitIds([])
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof GameClientSeamError
-          ? `GameClientSeamError: ${error.message}`
-          : error instanceof Error && error.message
-            ? `Error: ${error.message}`
-            : 'Error unknown'
-      setActionError(`Failed to submit action: ${errorMessage}`)
-    }
+    await commitClientAction({ type: 'MOVE', unitId, to })
+    setSelectedUnitIds([])
   }
 
   const authoritativeState = clientSnapshot?.authoritativeState ?? null
@@ -1106,6 +1107,13 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
           resolution={pendingCombatResolution}
           modifiers={selectedCombatTarget.modifiers}
           onDismiss={handleDismissCombatResolution}
+        />
+      ) : null}
+      {pendingRamResolution ? (
+        <MoveResolutionToast
+          title={formatRamResolutionTitle(pendingRamResolution)}
+          resolution={pendingRamResolution}
+          onDismiss={handleDismissRamResolution}
         />
       ) : null}
       <header className="topbar panel">
@@ -1309,7 +1317,7 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
                       <div className="summary-line">
                         <span>Treads <strong>{displayedOnion.treads}</strong></span>
                         <span>Moves <strong>{displayedOnion.movesRemaining}</strong></span>
-                        <span>Rams <strong>{displayedOnion.rams}</strong></span>
+                        <span>Rams remaining <strong>{displayedOnion.rams}</strong></span>
                       </div>
                       <div className="summary-line">
                         <span>Weapons <strong>{onionWeapons.operationalWeapons}</strong></span>
@@ -1513,7 +1521,7 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
                       <dd>{selectedInspectorOnion.movesRemaining}</dd>
                     </div>
                     <div>
-                      <dt>Rams</dt>
+                      <dt>Rams remaining</dt>
                       <dd>{selectedInspectorOnion.rams}</dd>
                     </div>
                     <div>

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -34,7 +34,7 @@ import {
   sanitizeApiProtocolTrafficEntry,
   subscribeApiProtocolTraffic,
 } from '../shared/apiProtocol'
-import { getUnitMovementAllowance } from '../shared/unitMovement'
+import { getUnitMovementAllowance, getUnitRamCapacity } from '../shared/unitMovement'
 import type { TargetRules, TurnPhase, UnitStatus, Weapon } from '../shared/types/index'
 import type {
   GameRequestTransport,
@@ -376,7 +376,7 @@ function buildLiveOnion(snapshot: GameSnapshot, activePhase: TurnPhase | null): 
   const movementRemainingByUnit = snapshot.movementRemainingByUnit ?? {}
   const movesAllowed = activePhase === null ? 0 : getUnitMovementAllowance('TheOnion', activePhase, onion.treads)
   const movesRemaining = activePhase === null ? 0 : movementRemainingByUnit[onion.id ?? 'onion-1'] ?? movesAllowed
-  const ramCapacity = 2
+  const ramCapacity = getUnitRamCapacity(onion.type ?? 'TheOnion')
   const ramsRemaining = Math.max(ramCapacity - (authoritativeState.ramsThisTurn ?? 0), 0)
 
   return {

--- a/web/components/HexMapBoard.tsx
+++ b/web/components/HexMapBoard.tsx
@@ -3,7 +3,7 @@ import { axialToPixel, boardPixelSize, hexCorners, pointsToString } from '../lib
 import { unitCode, type BattlefieldOnionView, type BattlefieldUnit, type TerrainHex } from '../lib/battlefieldView'
 import { hexKey } from '../../shared/hex'
 import { listReachableMoves } from '../../shared/movePlanner'
-import { canUnitCrossRidgelines, getUnitMovementAllowance } from '../../shared/unitMovement'
+import { getUnitMovementAllowance } from '../../shared/unitMovement'
 import './HexMapBoard.css'
 
 type HexOccupant = BattlefieldUnit | BattlefieldOnionView
@@ -115,7 +115,6 @@ export function HexMapBoard({ scenarioMap, defenders, onion, phase, viewerRole =
         ? selectedOccupant.move
         : 0
     : 0
-  const selectedCanCrossRidgelines = selectedOccupant ? canUnitCrossRidgelines(selectedOccupant.type) : false
   const occupiedHexes = Array.from(occupantMap.entries())
     .flatMap(([key, occupants]) => {
       const [q, r] = key.split(',').map(Number)
@@ -136,7 +135,6 @@ export function HexMapBoard({ scenarioMap, defenders, onion, phase, viewerRole =
           map: { ...scenarioMap, occupiedHexes },
           from: { q: selectedOccupant.q, r: selectedOccupant.r },
           movementAllowance: selectedAllowance,
-          canCrossRidgelines: selectedCanCrossRidgelines,
           movingRole: selectedOccupant.id === onion.id ? 'onion' : 'defender',
           movingUnitType: selectedOccupant.type,
         }).map((move) => hexKey(move.to)),

--- a/web/components/MoveResolutionToast.tsx
+++ b/web/components/MoveResolutionToast.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from 'react'
+import type { RamResolution } from '../lib/gameClient'
+
+type MoveResolutionToastProps = {
+	title: string
+	resolution: RamResolution
+	onDismiss: () => void
+}
+
+export function MoveResolutionToast({ title, resolution, onDismiss }: MoveResolutionToastProps) {
+	useEffect(() => {
+		const timer = window.setTimeout(() => {
+			onDismiss()
+		}, 10_000)
+
+		return () => {
+			window.clearTimeout(timer)
+		}
+	}, [onDismiss])
+
+	return (
+		<aside className="combat-resolution-toast" role="status" aria-live="polite" data-testid="ram-resolution-toast">
+			<div className="combat-resolution-head">
+				<div>
+					<p className="eyebrow">Ram result</p>
+					<h3>{title}</h3>
+				</div>
+				<span className="mini-tag mini-tag-live">Resolved</span>
+			</div>
+
+			<div className="combat-resolution-stats">
+				<div className="combat-resolution-stat">
+					<span className="stat-label-small">Rammed</span>
+					<strong>{resolution.rammedUnitIds.length}</strong>
+				</div>
+				{resolution.treadDamage !== undefined ? (
+					<div className="combat-resolution-stat">
+						<span className="stat-label-small">Tread loss</span>
+						<strong>{resolution.treadDamage}</strong>
+					</div>
+				) : null}
+				<div className="combat-resolution-stat">
+					<span className="stat-label-small">Destroyed</span>
+					<strong>{resolution.destroyedUnitIds.length}</strong>
+				</div>
+			</div>
+
+			<div className="combat-resolution-section">
+				<span className="stat-label-small">Effects</span>
+				{resolution.details.length > 0 ? (
+					<ul className="combat-resolution-list">
+						{resolution.details.map((detail) => (
+							<li key={detail}>{detail}</li>
+						))}
+					</ul>
+				) : (
+					<p className="summary-line">No additional effects.</p>
+				)}
+			</div>
+
+			<div className="combat-resolution-actions">
+				<button
+					className="combat-resolution-dismiss"
+					type="button"
+					onClick={(event) => {
+						event.stopPropagation()
+						onDismiss()
+					}}
+				>
+					Dismiss
+				</button>
+			</div>
+		</aside>
+	)
+}

--- a/web/lib/combatPreview.ts
+++ b/web/lib/combatPreview.ts
@@ -1,10 +1,9 @@
 import type { TerrainType } from '../../shared/engineTypes.js'
-import { getAllUnitDefinitions } from '../../shared/unitDefinitions.js'
 import {
 	createCombatCalculator,
 	type CombatCalculatorInput,
-	type CombatStaticRules,
 	} from '../../shared/combatCalculator.js'
+import { ONION_STATIC_RULES } from '../../shared/staticRules.js'
 import {
 	isTargetAllowedByRules,
 	resolveUnitTargetRules,
@@ -38,14 +37,7 @@ type CombatPreviewInput = {
 	displayedScenarioMap: { width: number; height: number; cells?: Array<{ q: number; r: number }>; hexes: TerrainHex[] } | null
 }
 
-const combatRules: CombatStaticRules = {
-	unitDefinitions: getAllUnitDefinitions(),
-	terrainRules: {
-		clear: { terrainType: 'clear' },
-		ridgeline: { terrainType: 'ridgeline', defenseBonus: 1 },
-		crater: { terrainType: 'crater' },
-	},
-}
+const combatRules = ONION_STATIC_RULES
 
 const combatCalculator = createCombatCalculator(combatRules)
 

--- a/web/lib/gameClient.ts
+++ b/web/lib/gameClient.ts
@@ -23,6 +23,15 @@ export type CombatResolution = {
 	details: string[]
 }
 
+export type RamResolution = {
+	actionType: 'MOVE'
+	unitId: string
+	rammedUnitIds: string[]
+	destroyedUnitIds: string[]
+	treadDamage?: number
+	details: string[]
+}
+
 export type GameSnapshot = {
 	gameId: number
 	phase: TurnPhase
@@ -35,6 +44,7 @@ export type GameSnapshot = {
 	movementRemainingByUnit?: Record<string, number>
 	scenarioMap?: ScenarioMapSnapshot
 	combatResolution?: CombatResolution
+	ramResolution?: RamResolution
 }
 
 export type GameSessionContext = {

--- a/web/lib/httpGameClient.ts
+++ b/web/lib/httpGameClient.ts
@@ -12,6 +12,7 @@ import type { GameRequestTransport } from './gameSessionTypes'
 import { requestJson, type ApiFailure, type EventsResponse, type GameStateResponse } from '../../shared/apiProtocol'
 import type { GameState, TurnPhase } from '../../shared/types/index'
 import { buildCombatResolution } from './combatResolution'
+import { buildRamResolution } from './moveResolution'
 
 type ActionSuccessResponse = {
 	ok: true
@@ -140,6 +141,7 @@ function mapActionSnapshot(
 		authoritativeState: response.state ?? fallback.authoritativeState,
 		movementRemainingByUnit: response.movementRemainingByUnit ?? fallback.movementRemainingByUnit,
 		combatResolution: buildCombatResolution(response.events),
+		ramResolution: buildRamResolution(response.events),
 	})
 }
 

--- a/web/lib/moveResolution.ts
+++ b/web/lib/moveResolution.ts
@@ -1,0 +1,76 @@
+export type MoveResolutionEvent = {
+	type: string
+	[key: string]: unknown
+}
+
+function getStringArray(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function getNumber(value: unknown): number | undefined {
+	return typeof value === 'number' ? value : undefined
+}
+
+export type RamResolution = {
+	actionType: 'MOVE'
+	unitId: string
+	rammedUnitIds: string[]
+	destroyedUnitIds: string[]
+	treadDamage?: number
+	details: string[]
+}
+
+export function formatRamResolutionTitle(resolution: RamResolution): string {
+	if (resolution.destroyedUnitIds.length > 0 && resolution.treadDamage !== undefined && resolution.treadDamage > 0) {
+		return `Ram resolved: ${resolution.destroyedUnitIds.length} destroyed, Onion lost ${resolution.treadDamage} tread${resolution.treadDamage === 1 ? '' : 's'}`
+	}
+
+	if (resolution.destroyedUnitIds.length > 0) {
+		return `Ram resolved: ${resolution.destroyedUnitIds.length} destroyed`
+	}
+
+	if (resolution.treadDamage !== undefined && resolution.treadDamage > 0) {
+		return `Ram resolved: target survived, Onion lost ${resolution.treadDamage} tread${resolution.treadDamage === 1 ? '' : 's'}`
+	}
+
+	return 'Ram resolved'
+}
+
+export function buildRamResolution(events: ReadonlyArray<MoveResolutionEvent>): RamResolution | undefined {
+	const moveEvent = events.find((event) => event.type === 'MOVE_RESOLVED')
+	if (moveEvent === undefined) {
+		return undefined
+	}
+
+	const rammedUnitIds = getStringArray(moveEvent.rammedUnitIds)
+	const destroyedUnitIds = getStringArray(moveEvent.destroyedUnitIds)
+	const details: string[] = []
+
+	if (rammedUnitIds.length > 0) {
+		details.push(`Rammed units: ${rammedUnitIds.join(', ')}`)
+	}
+
+	for (const event of events) {
+		switch (event.type) {
+			case 'ONION_TREADS_LOST':
+				if (typeof event.amount === 'number' && typeof event.remaining === 'number') {
+					details.push(`Treads lost: ${event.amount} (remaining ${event.remaining})`)
+				}
+				break
+			case 'UNIT_STATUS_CHANGED':
+				if (typeof event.unitId === 'string' && typeof event.from === 'string' && typeof event.to === 'string') {
+					details.push(`Destroyed unit: ${event.unitId} ${event.from} → ${event.to}`)
+				}
+				break
+		}
+	}
+
+	return {
+		actionType: 'MOVE',
+		unitId: typeof moveEvent.unitId === 'string' ? moveEvent.unitId : 'unknown',
+		rammedUnitIds,
+		destroyedUnitIds,
+		treadDamage: getNumber(moveEvent.treadDamage),
+		details,
+	}
+}


### PR DESCRIPTION
This branch implements the shared rules platform refactor described in [docs/shared-rules-platform-refactor-spec.md](docs/shared-rules-platform-refactor-spec.md).

The work treats the original three tasks as one coordinated update:
- externalize unit and weapon definitions into shared data so the engine no longer owns a parallel rules table
- consolidate movement profiles, terrain-entry/cover logic, stacking legality, and pathfinding into shared rule-query helpers and shared move planning
- extract a standalone shared ramming calculator and wire engine movement through it

The implementation also moves the web and server consumers onto the new shared rule seams so the engine and UI both derive behavior from the same canonical source of truth. That includes the static rules bundle boundary, movement-rule queries, combat consumers, and the web-side movement/ramming notifications that depend on the new action result shape.

Validation was kept tight around the affected slices, with focused tests for shared movement, ramming, combat, and the UI transport/notification path, plus backend and web builds.
