### PR TITLE
Opponent’s Results: Inactive event stream, UI, and backend integration

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,7 +5,10 @@ break down into features/tasks as needed.
 
 ## In progress
 
-- [ ] Decompose two large files into modules via the obvious responsibility boundaries in order to imporve agent effectiveness: server/api/games.ts and web/App.tsx
+- [ ] Add event-driven toasts for inactive players so the non-active client can surface actions taken by the other side (for example: MOVE ram results, combat outcomes, unit destruction, and phase changes).
+  - [ ] Define which events should trigger passive toasts, how they are deduplicated, and how they should appear when the player is not the active actor.
+  - [ ] Implement event stream emmission for any new or modified events
+  - [ ] Render inactive player toasts
 
 ## Epics / Major Work
 
@@ -19,8 +22,6 @@ break down into features/tasks as needed.
 ## Features / Work Items
 
 - [ ] Replace the debug protocol viewer with `@uiw/react-json-view` and add custom expansion shortcuts for deep-dive trees (for example: double-click subtree expand/collapse and expand-all controls).
-- [ ] Add event-driven toasts for inactive players so the non-active client can surface actions taken by the other side (for example: MOVE ram results, combat outcomes, unit destruction, and phase changes).
-  - [ ] Define which events should trigger passive toasts, how they are deduplicated, and how they should appear when the player is not the active actor.
 
 ## Done
 
@@ -88,3 +89,4 @@ break down into features/tasks as needed.
   - [x] Collapse the current split between movement profiles, pathfinding, and stacking rules so terrain entry, cover, and occupancy checks all come from the same unit/terrain definition model.
   - [x] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
 - [x] Add more robust server-side logging that includes event details for MOVE and FIRE outcomes.
+- [x] Decompose two large files into modules via the obvious responsibility boundaries in order to improve agent effectiveness: server/api/games.ts and web/App.tsx

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,10 +5,15 @@ break down into features/tasks as needed.
 
 ## In progress
 
-- [ ] Add event-driven toasts for inactive players so the non-active client can surface actions taken by the other side (for example: MOVE ram results, combat outcomes, unit destruction, and phase changes).
-  - [ ] Define which events should trigger passive toasts, how they are deduplicated, and how they should appear when the player is not the active actor.
-  - [ ] Implement event stream emmission for any new or modified events
-  - [ ] Render inactive player toasts
+
+- [ ] Add a reviewable "Opponent’s Results" stream for the non-active client to surface actions taken by the other side (combat attempts/results, unit destruction, ram outcomes, phase changes).
+  - [x] Define the event stream contract: show remote-visible outcomes from persisted events, not the local player's own pending action state.
+    - [x] Include combat attempts (even misses), `MOVE_RESOLVED` ram results, `UNIT_STATUS_CHANGED` for destroyed units, and `PHASE_CHANGED` for phase advances.
+    - [x] Deduplicate by event seq so reconnects, refreshes, and repeated live hints cannot show the same entry twice.
+    - [x] Keep the content compact and reviewable: append one entry per meaningful event, let the user dismiss the stream, and only show new events after dismissal.
+    - [x] Skip the active player's own result overlay, since that remains covered by the existing resolution UI.
+  - [ ] Implement event stream emission for any new or modified events (backend)
+  - [x] Render the "Opponent’s Results" UI as a compact, scrollable right-rail panel with one-line summaries per event.
 
 ## Epics / Major Work
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,16 +5,6 @@ break down into features/tasks as needed.
 
 ## In progress
 
-
-- [ ] Add a reviewable "Opponent’s Results" stream for the non-active client to surface actions taken by the other side (combat attempts/results, unit destruction, ram outcomes, phase changes).
-  - [x] Define the event stream contract: show remote-visible outcomes from persisted events, not the local player's own pending action state.
-    - [x] Include combat attempts (even misses), `MOVE_RESOLVED` ram results, `UNIT_STATUS_CHANGED` for destroyed units, and `PHASE_CHANGED` for phase advances.
-    - [x] Deduplicate by event seq so reconnects, refreshes, and repeated live hints cannot show the same entry twice.
-    - [x] Keep the content compact and reviewable: append one entry per meaningful event, let the user dismiss the stream, and only show new events after dismissal.
-    - [x] Skip the active player's own result overlay, since that remains covered by the existing resolution UI.
-  - [ ] Implement event stream emission for any new or modified events (backend)
-  - [x] Render the "Opponent’s Results" UI as a compact, scrollable right-rail panel with one-line summaries per event.
-
 ## Epics / Major Work
 
 - [ ] Improve error handling (UI and backend)
@@ -95,3 +85,11 @@ break down into features/tasks as needed.
   - [x] Add a standalone shared ramming calculator that consumes the same unit capability data and resolves tread loss or destruction outcomes.
 - [x] Add more robust server-side logging that includes event details for MOVE and FIRE outcomes.
 - [x] Decompose two large files into modules via the obvious responsibility boundaries in order to improve agent effectiveness: server/api/games.ts and web/App.tsx
+- [x] Add a reviewable "Opponent’s Results" stream for the non-active client to surface actions taken by the other side (combat attempts/results, unit destruction, ram outcomes, phase changes).
+  - [x] Define the event stream contract: show remote-visible outcomes from persisted events, not the local player's own pending action state.
+    - [x] Include combat attempts (even misses), `MOVE_RESOLVED` ram results, `UNIT_STATUS_CHANGED` for destroyed units, and `PHASE_CHANGED` for phase advances.
+    - [x] Deduplicate by event seq so reconnects, refreshes, and repeated live hints cannot show the same entry twice.
+    - [x] Keep the content compact and reviewable: append one entry per meaningful event, let the user dismiss the stream, and only show new events after dismissal.
+    - [x] Skip the active player's own result overlay, since that remains covered by the existing resolution UI.
+  - [x] Implement event stream emission for any new or modified events (backend)
+  - [x] Render the "Opponent’s Results" UI as a compact, scrollable right-rail panel with one-line summaries per event.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -17,6 +17,7 @@ break down into features/tasks as needed.
 ## Features / Work Items
 
 - [ ] Replace the debug protocol viewer with `@uiw/react-json-view` and add custom expansion shortcuts for deep-dive trees (for example: double-click subtree expand/collapse and expand-all controls).
+- [ ] Make client side logging verbosity level sensitive; move existing console logs to proper levels.
 
 ## Done
 

--- a/test/web/app/ui/App.ui.test.tsx
+++ b/test/web/app/ui/App.ui.test.tsx
@@ -8,6 +8,7 @@ import App from '../../../../web/App'
 import { createGameClient, type GameSnapshot } from '../../../../web/lib/gameClient'
 import { clearApiProtocolTraffic, requestJson } from '../../../../shared/apiProtocol'
 import type { GameState } from '../../../../shared/types/index'
+import type { LiveEventSource, LiveSessionSignal } from '../../../../web/lib/gameSessionTypes'
 
 type LoadedBattlefieldSnapshot = GameSnapshot & {
 	authoritativeState: GameState
@@ -157,6 +158,40 @@ function createOnionMoveSnapshot(selectedUnitId: string | null = null, onionMove
 			'onion-1': onionMovesRemaining,
 			'wolf-2': 4,
 			'puss-1': 3,
+		},
+	}
+}
+
+function createLiveEventSourceStub() {
+	const listeners = new Set<(signal: LiveSessionSignal) => void>()
+	let connectionStatus: 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected' = 'idle'
+
+	return {
+		subscribe(listener: (signal: LiveSessionSignal) => void) {
+			listeners.add(listener)
+			return () => {
+				listeners.delete(listener)
+			}
+		},
+		connect(gameId: number) {
+			connectionStatus = 'connected'
+			for (const listener of listeners) {
+				listener({ kind: 'connection', gameId, status: 'connected' })
+			}
+		},
+		disconnect(gameId: number) {
+			connectionStatus = 'disconnected'
+			for (const listener of listeners) {
+				listener({ kind: 'connection', gameId, status: 'disconnected' })
+			}
+		},
+		getConnectionState() {
+			return connectionStatus
+		},
+		emit(signal: LiveSessionSignal) {
+			for (const listener of listeners) {
+				listener(signal)
+			}
 		},
 	}
 }
@@ -428,6 +463,139 @@ describe('App UI', () => {
 		expect(screen.getByText(/Ram result/i)).not.toBeNull()
 		expect(screen.getByRole('heading', { name: /Ram resolved: target survived, Onion lost 1 tread/i })).not.toBeNull()
 		expect(screen.getByText(/Rammed units: puss-1/i)).not.toBeNull()
+	})
+
+	it('shows a dismissible inactive-event stream for remote combat events', async () => {
+		const user = userEvent.setup()
+		const snapshot = createOnionMoveSnapshot(null, 4)
+		const liveEventSource = createLiveEventSourceStub()
+		const pollEvents = vi.fn().mockImplementation(async (_gameId: number, afterSeq: number) => {
+			if (afterSeq === 0) {
+				return [
+					{
+						seq: 48,
+						type: 'FIRE_RESOLVED',
+						summary: 'Wolf-2 fired at the Onion and missed.',
+						timestamp: '2026-04-15T12:00:00.000Z',
+					},
+				]
+			}
+
+			return [
+				{
+					seq: 49,
+					type: 'MOVE_RESOLVED',
+					summary: 'Puss-1 rammed the Onion and retreated.',
+					timestamp: '2026-04-15T12:01:00.000Z',
+				},
+			]
+		})
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session: { role: 'defender' as const } }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents,
+		})
+
+		render(<App gameClient={client} gameId={123} liveEventSource={liveEventSource as LiveEventSource} />)
+
+		await screen.findByRole('button', { name: /toggle debug diagnostics/i })
+		expect(await screen.findByTestId('inactive-event-stream')).not.toBeNull()
+		expect(screen.getByText(/Wolf-2 fired at the Onion and missed\./i)).not.toBeNull()
+		expect(pollEvents).toHaveBeenCalledWith(123, 0)
+		expect(screen.getByTestId('inactive-event-stream').closest('.rail-right')).not.toBeNull()
+
+		act(() => {
+			liveEventSource.emit({ kind: 'event', gameId: 123, eventSeq: 48, eventType: 'FIRE_RESOLVED' })
+		})
+
+		await user.click(screen.getByRole('button', { name: /dismiss inactive event stream/i }))
+		expect(screen.queryByTestId('inactive-event-stream')).toBeNull()
+
+		act(() => {
+			liveEventSource.emit({ kind: 'event', gameId: 123, eventSeq: 49, eventType: 'MOVE_RESOLVED' })
+		})
+
+		expect(await screen.findByText(/Puss-1 rammed the Onion and retreated\./i)).not.toBeNull()
+		expect(screen.queryByText(/Wolf-2 fired at the Onion and missed\./i)).toBeNull()
+	})
+
+	it('loads historical inactive events on initial defender login', async () => {
+		const snapshot = createOnionMoveSnapshot(null, 4)
+		const liveEventSource = createLiveEventSourceStub()
+		const pollEvents = vi.fn().mockResolvedValue([
+			{
+				seq: 48,
+				type: 'FIRE_RESOLVED',
+				summary: 'Wolf-2 fired at the Onion and missed.',
+				timestamp: '2026-04-15T12:00:00.000Z',
+			},
+		])
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session: { role: 'defender' as const } }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents,
+		})
+
+		render(<App gameClient={client} gameId={123} liveEventSource={liveEventSource as LiveEventSource} />)
+
+		expect(await screen.findByTestId('inactive-event-stream')).not.toBeNull()
+		expect(screen.getByText(/Wolf-2 fired at the Onion and missed\./i)).not.toBeNull()
+		expect(pollEvents).toHaveBeenCalledWith(123, 0)
+	})
+
+	it('keeps dismissed inactive events hidden when later polls include older seqs again', async () => {
+		const user = userEvent.setup()
+		const snapshot = createOnionMoveSnapshot(null, 4)
+		const liveEventSource = createLiveEventSourceStub()
+		const pollEvents = vi.fn().mockImplementation(async (_gameId: number, afterSeq: number) => {
+			if (afterSeq === 0) {
+				return [
+					{
+						seq: 48,
+						type: 'FIRE_RESOLVED',
+						summary: 'Wolf-2 fired at the Onion and missed.',
+						timestamp: '2026-04-15T12:00:00.000Z',
+					},
+				]
+			}
+
+			return [
+				{
+					seq: 48,
+					type: 'FIRE_RESOLVED',
+					summary: 'Wolf-2 fired at the Onion and missed.',
+					timestamp: '2026-04-15T12:00:00.000Z',
+				},
+				{
+					seq: 49,
+					type: 'MOVE_RESOLVED',
+					summary: 'Puss-1 rammed the Onion and retreated.',
+					timestamp: '2026-04-15T12:01:00.000Z',
+				},
+			]
+		})
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session: { role: 'defender' as const } }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents,
+		})
+
+		render(<App gameClient={client} gameId={123} liveEventSource={liveEventSource as LiveEventSource} />)
+
+		expect(await screen.findByTestId('inactive-event-stream')).not.toBeNull()
+		expect(screen.getByText(/Wolf-2 fired at the Onion and missed\./i)).not.toBeNull()
+
+		await user.click(screen.getByRole('button', { name: /dismiss inactive event stream/i }))
+		expect(screen.queryByTestId('inactive-event-stream')).toBeNull()
+
+		act(() => {
+			liveEventSource.emit({ kind: 'event', gameId: 123, eventSeq: 49, eventType: 'MOVE_RESOLVED' })
+		})
+
+		expect(await screen.findByText(/Puss-1 rammed the Onion and retreated\./i)).not.toBeNull()
+		expect(screen.queryByText(/Wolf-2 fired at the Onion and missed\./i)).toBeNull()
+		expect(pollEvents).toHaveBeenCalledWith(123, 0)
+		expect(pollEvents).toHaveBeenCalledWith(123, 48)
 	})
 
 	it('preserves debug popup position and size when toggled closed and reopened', async () => {

--- a/web/App.css
+++ b/web/App.css
@@ -408,6 +408,77 @@
   background: rgba(255, 251, 242, 0.78);
 }
 
+.inactive-event-stream {
+  padding: 16px 18px;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: clamp(240px, 34vh, 420px);
+  min-height: 0;
+}
+
+.inactive-event-stream-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.inactive-event-stream-head h3 {
+  margin: 0;
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.inactive-event-stream-dismiss {
+  flex: none;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: rgba(255, 251, 242, 0.92);
+  color: #5f4f25;
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.inactive-event-stream-list {
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.inactive-event-stream-entry {
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(191, 174, 122, 0.34);
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.inactive-event-stream-entry .summary-line {
+  margin: 0;
+  color: #332b1a;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tone-alert {
+  border-color: rgba(196, 61, 44, 0.22);
+  background: rgba(253, 238, 238, 0.78);
+}
+
 .topbar {
   display: flex;
   align-items: center;

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -18,6 +18,7 @@ import { useGameSession } from './lib/useGameSession'
 import { useDebugDiagnostics } from './lib/useDebugDiagnostics'
 import { useBattlefieldInteractionState } from './lib/useBattlefieldInteractionState'
 import { useBattlefieldDisplayState } from './lib/useBattlefieldDisplayState'
+import { useInactiveEventStream } from './lib/useInactiveEventStream'
 import type {
   GameRequestTransport,
   GameSessionController,
@@ -88,6 +89,9 @@ function createRequestTransportFromGameClient(gameClient: GameClient): GameReque
     submitAction(gameId: number, action: GameAction) {
       return gameClient.submitAction(gameId, action)
     },
+    pollEvents(gameId: number, afterSeq: number) {
+      return gameClient.pollEvents(gameId, afterSeq)
+    },
   }
 }
 
@@ -107,11 +111,24 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
 
   const activeSessionBinding = useMemo<SessionBinding | null>(() => {
     if (providedRequestTransport !== null && gameId !== undefined) {
+      if (typeof window !== 'undefined') {
+        console.info('[app] using provided request transport', {
+          gameId,
+          hasLiveEventSource: liveEventSource !== undefined,
+        })
+      }
       return {
         gameId,
         requestTransport: providedRequestTransport,
         liveEventSource: liveEventSource ?? idleLiveEventSource,
       }
+    }
+
+    if (typeof window !== 'undefined') {
+      console.info('[app] using connected session binding', {
+        hasConnectedSession: connectedSession !== null,
+        connectedGameId: connectedSession?.gameId ?? null,
+      })
     }
 
     return connectedSession
@@ -139,6 +156,13 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
   const sessionRole = sessionState.session?.role ?? null
   const activeTurnOwner = getPhaseOwner(sessionPhase)
   const sessionTurnActive = sessionState.snapshot !== null && sessionRole !== null && activeTurnOwner === sessionRole
+
+  const inactiveEventStream = useInactiveEventStream({
+    activeGameId: activeSessionBinding?.gameId ?? null,
+    activeTurnActive: sessionTurnActive,
+    lastAppliedEventSeq: sessionState.lastAppliedEventSeq,
+    pollEvents: activeSessionBinding?.requestTransport.pollEvents,
+  })
 
   const interactionState = useBattlefieldInteractionState({
     activeSessionController,
@@ -410,6 +434,7 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
           selectedCombatTargetId={selectedCombatTargetId}
           selectedInspectorDefender={selectedInspectorDefender}
           selectedInspectorOnion={selectedInspectorOnion}
+          inactiveEventStream={inactiveEventStream}
           combatTargetOptions={combatTargetOptions}
           onConfirmCombat={handleConfirmCombat}
           onSelectCombatTarget={setSelectedCombatTargetId}

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1,17 +1,16 @@
 import { useState, useMemo } from 'react'
-import { HexMapBoard } from './components/HexMapBoard'
-import { CombatConfirmationView } from './components/CombatConfirmationView'
 import { CombatResolutionToast } from './components/CombatResolutionToast'
 import { MoveResolutionToast } from './components/MoveResolutionToast'
 import { ErrorOverlay } from './components/ErrorOverlay'
 import { DraggableDebugPopup } from './components/DraggableDebugPopup'
 import { ConnectGate } from './components/ConnectGate'
-import { CombatTargetList } from './components/CombatTargetList'
+import { BattlefieldStage } from './components/BattlefieldStage'
+import { BattlefieldLeftRail } from './components/BattlefieldLeftRail'
+import { BattlefieldRightRail } from './components/BattlefieldRightRail'
 import {
   type GameAction,
   type GameClient,
 } from './lib/gameClient'
-import { statusTone } from './lib/battlefieldView'
 import { createGameSessionController } from './lib/gameSessionController'
 import type { WebRuntimeConfig } from './lib/appBootstrap'
 import { formatRamResolutionTitle } from './lib/moveResolution'
@@ -28,10 +27,7 @@ import type {
 import type { SessionBinding } from './lib/sessionBinding'
 import {
   buildCombatTargetActionId,
-  buildWeaponSelectionId,
   getPhaseOwner,
-  parseAttackStats,
-  parseWeaponStats,
 } from './lib/appViewHelpers'
 import './App.css'
 
@@ -353,339 +349,71 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
       )}
 
       <main className="battlefield-grid" onClick={handleDeselectUnit}>
-        <aside className="panel rail rail-left">
-          {isCombatPhase ? (
-            <section className="section-block combat-scaffold">
-              <div className="card-head">
-                <div>
-                  <p className="eyebrow">Combat</p>
-                  <h2 title={activeCombatRole === 'onion'
-                    ? 'Pick one or more eligible weapons from the rail. Ctrl+click adds or removes weapons from the attack group.'
-                    : 'Pick one or more eligible units from the rail or board. Ctrl+click adds or removes units from the attack group.'
-                  }>
-                    Attacker Selection
-                  </h2>
-                </div>
-                <span className="mini-tag mini-tag-live" data-testid="combat-attack-total">{selectedCombatAttackLabel}</span>
-              </div>
+        <BattlefieldLeftRail
+          activeCombatRole={activeCombatRole}
+          activeMode={activeMode}
+          activeSelectedUnitIds={activeSelectedUnitIds}
+          displayedDefenders={displayedDefenders}
+          displayedOnion={displayedOnion}
+          isCombatPhase={isCombatPhase}
+          isMovementPhase={isMovementPhase}
+          onionWeapons={onionWeapons}
+          readyWeaponDetails={readyWeaponDetails}
+          selectedCombatAttackLabel={selectedCombatAttackLabel}
+          onSelectDefenderCombatTarget={() => {
+            setSelectedUnitIds([])
+            setSelectedCombatTargetId('onion')
+          }}
+          onSelectUnit={handleSelectUnit}
+        />
 
-              <div className="attacker-selection-list">
-                {activeCombatRole === 'onion' ? (
-                  readyWeaponDetails.length > 0 ? (
-                    readyWeaponDetails.map((weapon) => {
-                      const selectionId = buildWeaponSelectionId(weapon.id)
-                      const isSelected = activeSelectedUnitIds.includes(selectionId)
-                      return (
-                        <button
-                          key={weapon.id}
-                          type="button"
-                          className={`attacker-card-button slim-weapon-card${isSelected ? ' is-selected' : ''}`}
-                          aria-pressed={isSelected}
-                          data-selected={isSelected}
-                          data-testid={`combat-weapon-${weapon.id}`}
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            handleSelectUnit(selectionId, event.ctrlKey || event.metaKey)
-                          }}
-                        >
-                          <div className="weapon-card-name">{weapon.name}</div>
-                          <div className="weapon-card-stats">Attack: {weapon.attack} &nbsp;·&nbsp; Range: {weapon.range}</div>
-                        </button>
-                      )
-                    })
-                  ) : (
-                    <p className="summary-line">No ready weapons available.</p>
-                  )
-                ) : displayedDefenders.length > 0 ? (
-                  displayedDefenders.map((unit) => {
-                    const isSelected = activeSelectedUnitIds.includes(unit.id)
-                    const isActionable = unit.actionableModes.includes(activeMode)
-                    const attackStats = parseAttackStats(unit.attack)
-                    const isDestroyed = unit.status === 'destroyed'
-                    const isDisabled = isDestroyed || !isActionable
-                    return (
-                      <button
-                        key={unit.id}
-                        type="button"
-                        className={[
-                          'attacker-card-button',
-                          isSelected ? 'is-selected' : '',
-                          isActionable ? 'is-actionable' : '',
-                          isDisabled ? 'is-disabled' : '',
-                          `tone-${statusTone(unit.status)}`,
-                        ].join(' ')}
-                        aria-pressed={isSelected}
-                        data-selected={isSelected}
-                        data-testid={`combat-unit-${unit.id}`}
-                        disabled={false} // Always allow click for inspector
-                        title={isDestroyed ? 'Destroyed units cannot attack.' : !isActionable ? 'This unit is not eligible to attack.' : undefined}
-                        onClick={(event) => {
-                          event.stopPropagation()
-                          handleSelectUnit(unit.id, event.ctrlKey || event.metaKey)
-                        }}
-                      >
-                        <div className="weapon-card-name">{unit.type}</div>
-                        <div className="weapon-card-stats">Attack: {attackStats.damage} &nbsp;·&nbsp; Range: {attackStats.range}</div>
-                      </button>
-                    )
-                  })
-                ) : (
-                  <p className="summary-line">Waiting for battlefield data.</p>
-                )}
-              </div>
-            </section>
-          ) : isMovementPhase ? (
-            activeRole === 'onion' ? (
-              <section className="section-block">
-                <div className="card-head">
-                  <p className="eyebrow">Onion</p>
-                </div>
-                {displayedOnion ? (
-                  <button
-                    type="button"
-                    className={`onion-card-button ${activeSelectedUnitIds.includes(displayedOnion.id) ? 'is-selected' : ''}`}
-                    aria-pressed={activeSelectedUnitIds.includes(displayedOnion.id)}
-                    data-selected={activeSelectedUnitIds.includes(displayedOnion.id)}
-                    data-testid={`combat-unit-${displayedOnion.id}`}
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      handleSelectUnit(displayedOnion.id, event.ctrlKey || event.metaKey)
-                    }}
-                  >
-                    <h3>{displayedOnion.id}</h3>
-                    <div className="unit-summary">
-                      <div className="summary-line">
-                        <span>Treads <strong>{displayedOnion.treads}</strong></span>
-                        <span>Moves <strong>{displayedOnion.movesRemaining}</strong></span>
-                        <span>Rams remaining <strong>{displayedOnion.rams}</strong></span>
-                      </div>
-                      <div className="summary-line">
-                        <span>Weapons <strong>{onionWeapons.operationalWeapons}</strong></span>
-                        <span>Missiles <strong>{onionWeapons.operationalMissiles}</strong></span>
-                      </div>
-                    </div>
-                  </button>
-                ) : (
-                  <p className="summary-line">Waiting for battlefield data.</p>
-                )}
-              </section>
-            ) : activeRole === 'defender' ? (
-              <section className="section-block">
-                <div className="card-head">
-                  <p className="eyebrow">Defenders</p>
-                  <span className="mini-tag">{displayedDefenders.length} tracked</span>
-                </div>
-                {displayedDefenders.length > 0 ? (
-                  <div className="defender-list">
-                    {displayedDefenders.map((unit) => {
-                      const isSelected = activeSelectedUnitIds.includes(unit.id)
-                      const isActionable = unit.actionableModes.includes(activeMode)
-                      const attackStats = parseAttackStats(unit.attack)
-                      const isDestroyed = unit.status === 'destroyed'
-                      return (
-                        <button
-                          key={unit.id}
-                          type="button"
-                          className={[
-                            'defender-card-button',
-                            'slim-weapon-card',
-                            isSelected ? 'is-selected' : '',
-                            isActionable ? 'is-actionable' : '',
-                            `tone-${statusTone(unit.status)}`,
-                          ].join(' ')}
-                          aria-pressed={isSelected}
-                          data-selected={isSelected}
-                          data-testid={`combat-unit-${unit.id}`}
-                          disabled={isDestroyed}
-                          onClick={(event) => {
-                            if (isDestroyed) {
-                              event.stopPropagation()
-                              return
-                            }
-                            event.stopPropagation()
-                            if (isCombatPhase && activeCombatRole === 'defender') {
-                              setSelectedUnitIds([])
-                              setSelectedCombatTargetId('onion')
-                            } else {
-                              handleSelectUnit(unit.id, event.ctrlKey || event.metaKey)
-                            }
-                          }}
-                        >
-                          <div className="weapon-card-name">{unit.type}</div>
-                          <div className="weapon-card-stats">Damage: {attackStats.damage} &nbsp;·&nbsp; Range: {attackStats.range} &nbsp;·&nbsp; Move: {unit.move}</div>
-                        </button>
-                      )
-                    })}
-                  </div>
-                ) : (
-                  <p className="summary-line">Waiting for battlefield data.</p>
-                )}
-              </section>
-            ) : null
-          ) : null}
-        </aside>
-
-        <section className="panel map-stage">
-          <div className="map-frame">
-            {displayedScenarioMap && displayedOnion ? (
-              <HexMapBoard
-                scenarioMap={displayedScenarioMap}
-                defenders={displayedDefenders}
-                onion={displayedOnion}
-                phase={activePhase}
-                viewerRole={activeRole}
-                selectedUnitIds={activeSelectedUnitIds}
-                selectedCombatTargetId={selectedCombatTargetId}
-                combatRangeHexKeys={combatRangeHexKeys}
-                combatTargetIds={combatTargetIds}
-                canSubmitMove={
-                  activeTurnActive && (
-                    activePhase === 'ONION_MOVE' ||
-                    activePhase === 'DEFENDER_MOVE' ||
-                    activePhase === 'GEV_SECOND_MOVE'
-                  )
-                }
-                onSelectUnit={handleSelectUnit}
-                onSelectCombatTarget={(targetId) => setSelectedCombatTargetId(targetId)}
-                onDeselect={handleDeselectUnit}
-                onMoveUnit={handleMoveUnit}
-              />
-            ) : (
+        {displayedScenarioMap && displayedOnion ? (
+          <BattlefieldStage
+            activePhase={activePhase}
+            activeTurnActive={activeTurnActive}
+            defenders={displayedDefenders}
+            onion={displayedOnion}
+            scenarioMap={displayedScenarioMap}
+            selectedCombatTargetId={selectedCombatTargetId}
+            selectedUnitIds={activeSelectedUnitIds}
+            combatRangeHexKeys={combatRangeHexKeys}
+            combatTargetIds={combatTargetIds}
+            canSubmitMove={
+              activePhase === 'ONION_MOVE' ||
+              activePhase === 'DEFENDER_MOVE' ||
+              activePhase === 'GEV_SECOND_MOVE'
+            }
+            viewerRole={activeRole}
+            onSelectUnit={handleSelectUnit}
+            onSelectCombatTarget={setSelectedCombatTargetId}
+            onDeselect={handleDeselectUnit}
+            onMoveUnit={handleMoveUnit}
+          />
+        ) : (
+          <section className="panel map-stage">
+            <div className="map-frame">
               <div className="hex-map-shell panel-subtle">
                 <p className="summary-line">Battlefield will appear once the game state loads.</p>
               </div>
-            )}
-          </div>
-        </section>
+            </div>
+          </section>
+        )}
 
-        <aside className="panel rail rail-right">
-          {/* Always show targeting list (combat UI) during defender combat phase; inspector only outside defender combat phase */}
-          {selectedInspectorOnion !== null ? (
-                <section className="selection-panel panel-subtle">
-                  <div className="selection-panel-header">
-                    <div>
-                      <p className="eyebrow">Inspector</p>
-                      <h2>{selectedInspectorOnion.type}</h2>
-                    </div>
-                    <span className="mini-tag">Selected</span>
-                  </div>
-                  <dl className="inspector-grid inspector-grid-right">
-                    <div>
-                      <dt>Stack</dt>
-                      <dd>1</dd>
-                    </div>
-                    <div>
-                      <dt>Treads</dt>
-                      <dd>{selectedInspectorOnion.treads}</dd>
-                    </div>
-                    <div>
-                      <dt>Moves</dt>
-                      <dd>{selectedInspectorOnion.movesRemaining}</dd>
-                    </div>
-                    <div>
-                      <dt>Rams remaining</dt>
-                      <dd>{selectedInspectorOnion.rams}</dd>
-                    </div>
-                    <div>
-                      <dt>Weapons</dt>
-                      <dd>{parseWeaponStats(selectedInspectorOnion.weapons ?? '').operationalWeapons}</dd>
-                    </div>
-                    <div>
-                      <dt>Missiles</dt>
-                      <dd>{parseWeaponStats(selectedInspectorOnion.weapons ?? '').operationalMissiles}</dd>
-                    </div>
-                  </dl>
-                </section>
-              ) : isCombatPhase && activeRole === activeCombatRole && (activeRole === 'defender' || selectedInspectorDefender === null) ? (
-                <section className="section-block panel-subtle">
-                  <div className="card-head">
-                    <div>
-                      <p className="eyebrow">Combat</p>
-                      <h2 title="Pick a target from the list. The list only includes targets currently in the active attack range.">
-                        Valid Targets
-                      </h2>
-                    </div>
-                    <span className="mini-tag">{combatTargetOptions.length} in range</span>
-                  </div>
-                  {selectedCombatTarget !== null ? (
-                    <CombatConfirmationView
-                      title={`Confirm attack on ${selectedCombatTarget.label}`}
-                      attackStrength={selectedCombatAttackStrength}
-                      defenseStrength={selectedCombatTarget.defense}
-                      modifiers={selectedCombatTarget.modifiers}
-                      confirmLabel="Resolve combat"
-                      onConfirm={handleConfirmCombat}
-                      dataTestId="combat-confirmation-view"
-                    />
-                  ) : null}
-                  {combatTargetOptions.length > 0 ? (
-                    <CombatTargetList
-                      targets={combatTargetOptions}
-                      selectedTargetId={selectedCombatTargetId}
-                      selectedCombatAttackCount={selectedCombatAttackCount}
-                      onSelectTarget={(targetId) => setSelectedCombatTargetId(targetId)}
-                    />
-                  ) : (
-                    <p className="summary-line">No valid targets are currently in range.</p>
-                  )}
-                </section>
-              ) : selectedInspectorDefender !== null ? (
-                <section className="selection-panel panel-subtle">
-                  <div className="selection-panel-header">
-                    <div>
-                      <p className="eyebrow">Inspector</p>
-                      <h2>{selectedInspectorDefender.type}</h2>
-                    </div>
-                    <span className="mini-tag">Selected</span>
-                  </div>
-                  <dl className="inspector-grid inspector-grid-right">
-                    <div>
-                      <dt>Stack</dt>
-                      <dd>{selectedInspectorDefender.type === 'LittlePigs' ? selectedInspectorDefender.squads ?? 1 : 1}</dd>
-                    </div>
-                    <div>
-                      <dt>Status</dt>
-                      <dd>{selectedInspectorDefender.status}</dd>
-                    </div>
-                    <div>
-                      <dt>Damage</dt>
-                      <dd>{parseAttackStats(selectedInspectorDefender.attack).damage}</dd>
-                    </div>
-                    <div>
-                      <dt>Range</dt>
-                      <dd>{parseAttackStats(selectedInspectorDefender.attack).range}</dd>
-                    </div>
-                    <div>
-                      <dt>Move</dt>
-                      <dd>{selectedInspectorDefender.move}</dd>
-                    </div>
-                    <div>
-                      <dt>Selected</dt>
-                      <dd>{activeSelectedUnitIds.length}</dd>
-                    </div>
-                  </dl>
-                </section>
-              ) : isCombatPhase ? (
-                <section className="selection-panel panel-subtle">
-                  <div className="selection-panel-header">
-                    <div>
-                      <p className="eyebrow">Inspector</p>
-                    </div>
-                  </div>
-                  <div className="empty-state">Select a unit on the map or in the rail to inspect it here.</div>
-                </section>
-              ) : (
-                <section className="selection-panel panel-subtle">
-                  <div className="selection-panel-header">
-                    <div>
-                      <p className="eyebrow">Inspector</p>
-                    </div>
-                  </div>
-                  <div className="empty-state">Select a unit on the map or in the rail to inspect it here.</div>
-                </section>
-              )
-          }
-        </aside>
+        <BattlefieldRightRail
+          activeCombatRole={activeCombatRole}
+          activeRole={activeRole}
+          activeSelectedUnitCount={activeSelectedUnitIds.length}
+          isCombatPhase={isCombatPhase}
+          selectedCombatAttackCount={selectedCombatAttackCount}
+          selectedCombatAttackStrength={selectedCombatAttackStrength}
+          selectedCombatTarget={selectedCombatTarget}
+          selectedCombatTargetId={selectedCombatTargetId}
+          selectedInspectorDefender={selectedInspectorDefender}
+          selectedInspectorOnion={selectedInspectorOnion}
+          combatTargetOptions={combatTargetOptions}
+          onConfirmCombat={handleConfirmCombat}
+          onSelectCombatTarget={setSelectedCombatTargetId}
+        />
       </main>
     </div>
   )

--- a/web/components/BattlefieldLeftRail.tsx
+++ b/web/components/BattlefieldLeftRail.tsx
@@ -187,11 +187,7 @@ export function BattlefieldLeftRail({
                           return
                         }
                         event.stopPropagation()
-                        if (activeCombatRole === 'defender') {
-                          onSelectDefenderCombatTarget()
-                        } else {
-                          onSelectUnit(unit.id, event.ctrlKey || event.metaKey)
-                        }
+                        onSelectDefenderCombatTarget()
                       }}
                     >
                       <div className="weapon-card-name">{unit.type}</div>

--- a/web/components/BattlefieldLeftRail.tsx
+++ b/web/components/BattlefieldLeftRail.tsx
@@ -1,0 +1,211 @@
+import { statusTone, type BattlefieldOnionView, type BattlefieldUnit, type Mode } from '../lib/battlefieldView'
+import { buildWeaponSelectionId, parseAttackStats } from '../lib/appViewHelpers'
+import type { Weapon } from '../../shared/types/index'
+
+type BattlefieldLeftRailProps = {
+  activeCombatRole: 'onion' | 'defender' | null
+  activeMode: Mode
+  activeSelectedUnitIds: string[]
+  displayedDefenders: ReadonlyArray<BattlefieldUnit>
+  displayedOnion: BattlefieldOnionView | null
+  isCombatPhase: boolean
+  isMovementPhase: boolean
+  onionWeapons: {
+    operationalWeapons: number
+    operationalMissiles: number
+  }
+  readyWeaponDetails: ReadonlyArray<Weapon>
+  selectedCombatAttackLabel: string
+  onSelectDefenderCombatTarget: () => void
+  onSelectUnit: (unitId: string, additive?: boolean) => void
+}
+
+export function BattlefieldLeftRail({
+  activeCombatRole,
+  activeMode,
+  activeSelectedUnitIds,
+  displayedDefenders,
+  displayedOnion,
+  isCombatPhase,
+  isMovementPhase,
+  onionWeapons,
+  readyWeaponDetails,
+  selectedCombatAttackLabel,
+  onSelectDefenderCombatTarget,
+  onSelectUnit,
+}: BattlefieldLeftRailProps) {
+  return (
+    <aside className="panel rail rail-left">
+      {isCombatPhase ? (
+        <section className="section-block combat-scaffold">
+          <div className="card-head">
+            <div>
+              <p className="eyebrow">Combat</p>
+              <h2
+                title={activeCombatRole === 'onion'
+                  ? 'Pick one or more eligible weapons from the rail. Ctrl+click adds or removes weapons from the attack group.'
+                  : 'Pick one or more eligible units from the rail or board. Ctrl+click adds or removes units from the attack group.'
+                }
+              >
+                Attacker Selection
+              </h2>
+            </div>
+            <span className="mini-tag mini-tag-live" data-testid="combat-attack-total">{selectedCombatAttackLabel}</span>
+          </div>
+
+          <div className="attacker-selection-list">
+            {activeCombatRole === 'onion' ? (
+              readyWeaponDetails.length > 0 ? (
+                readyWeaponDetails.map((weapon) => {
+                  const selectionId = buildWeaponSelectionId(weapon.id)
+                  const isSelected = activeSelectedUnitIds.includes(selectionId)
+                  return (
+                    <button
+                      key={weapon.id}
+                      type="button"
+                      className={`attacker-card-button slim-weapon-card${isSelected ? ' is-selected' : ''}`}
+                      aria-pressed={isSelected}
+                      data-selected={isSelected}
+                      data-testid={`combat-weapon-${weapon.id}`}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        onSelectUnit(selectionId, event.ctrlKey || event.metaKey)
+                      }}
+                    >
+                      <div className="weapon-card-name">{weapon.name}</div>
+                      <div className="weapon-card-stats">Attack: {weapon.attack} &nbsp;·&nbsp; Range: {weapon.range}</div>
+                    </button>
+                  )
+                })
+              ) : (
+                <p className="summary-line">No ready weapons available.</p>
+              )
+            ) : displayedDefenders.length > 0 ? (
+              displayedDefenders.map((unit) => {
+                const isSelected = activeSelectedUnitIds.includes(unit.id)
+                const isActionable = unit.actionableModes.includes(activeMode)
+                const attackStats = parseAttackStats(unit.attack)
+                const isDestroyed = unit.status === 'destroyed'
+                const isDisabled = isDestroyed || !isActionable
+                return (
+                  <button
+                    key={unit.id}
+                    type="button"
+                    className={[
+                      'attacker-card-button',
+                      isSelected ? 'is-selected' : '',
+                      isActionable ? 'is-actionable' : '',
+                      isDisabled ? 'is-disabled' : '',
+                      `tone-${statusTone(unit.status)}`,
+                    ].join(' ')}
+                    aria-pressed={isSelected}
+                    data-selected={isSelected}
+                    data-testid={`combat-unit-${unit.id}`}
+                    disabled={false}
+                    title={isDestroyed ? 'Destroyed units cannot attack.' : !isActionable ? 'This unit is not eligible to attack.' : undefined}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      onSelectUnit(unit.id, event.ctrlKey || event.metaKey)
+                    }}
+                  >
+                    <div className="weapon-card-name">{unit.type}</div>
+                    <div className="weapon-card-stats">Attack: {attackStats.damage} &nbsp;·&nbsp; Range: {attackStats.range}</div>
+                  </button>
+                )
+              })
+            ) : (
+              <p className="summary-line">Waiting for battlefield data.</p>
+            )}
+          </div>
+        </section>
+      ) : isMovementPhase ? (
+        activeCombatRole === 'onion' ? (
+          <section className="section-block">
+            <div className="card-head">
+              <p className="eyebrow">Onion</p>
+            </div>
+            {displayedOnion ? (
+              <button
+                type="button"
+                className={`onion-card-button ${activeSelectedUnitIds.includes(displayedOnion.id) ? 'is-selected' : ''}`}
+                aria-pressed={activeSelectedUnitIds.includes(displayedOnion.id)}
+                data-selected={activeSelectedUnitIds.includes(displayedOnion.id)}
+                data-testid={`combat-unit-${displayedOnion.id}`}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onSelectUnit(displayedOnion.id, event.ctrlKey || event.metaKey)
+                }}
+              >
+                <h3>{displayedOnion.id}</h3>
+                <div className="unit-summary">
+                  <div className="summary-line">
+                    <span>Treads <strong>{displayedOnion.treads}</strong></span>
+                    <span>Moves <strong>{displayedOnion.movesRemaining}</strong></span>
+                    <span>Rams remaining <strong>{displayedOnion.rams}</strong></span>
+                  </div>
+                  <div className="summary-line">
+                    <span>Weapons <strong>{onionWeapons.operationalWeapons}</strong></span>
+                    <span>Missiles <strong>{onionWeapons.operationalMissiles}</strong></span>
+                  </div>
+                </div>
+              </button>
+            ) : (
+              <p className="summary-line">Waiting for battlefield data.</p>
+            )}
+          </section>
+        ) : activeCombatRole === 'defender' ? (
+          <section className="section-block">
+            <div className="card-head">
+              <p className="eyebrow">Defenders</p>
+              <span className="mini-tag">{displayedDefenders.length} tracked</span>
+            </div>
+            {displayedDefenders.length > 0 ? (
+              <div className="defender-list">
+                {displayedDefenders.map((unit) => {
+                  const isSelected = activeSelectedUnitIds.includes(unit.id)
+                  const isActionable = unit.actionableModes.includes(activeMode)
+                  const attackStats = parseAttackStats(unit.attack)
+                  const isDestroyed = unit.status === 'destroyed'
+                  return (
+                    <button
+                      key={unit.id}
+                      type="button"
+                      className={[
+                        'defender-card-button',
+                        'slim-weapon-card',
+                        isSelected ? 'is-selected' : '',
+                        isActionable ? 'is-actionable' : '',
+                        `tone-${statusTone(unit.status)}`,
+                      ].join(' ')}
+                      aria-pressed={isSelected}
+                      data-selected={isSelected}
+                      data-testid={`combat-unit-${unit.id}`}
+                      disabled={isDestroyed}
+                      onClick={(event) => {
+                        if (isDestroyed) {
+                          event.stopPropagation()
+                          return
+                        }
+                        event.stopPropagation()
+                        if (activeCombatRole === 'defender') {
+                          onSelectDefenderCombatTarget()
+                        } else {
+                          onSelectUnit(unit.id, event.ctrlKey || event.metaKey)
+                        }
+                      }}
+                    >
+                      <div className="weapon-card-name">{unit.type}</div>
+                      <div className="weapon-card-stats">Damage: {attackStats.damage} &nbsp;·&nbsp; Range: {attackStats.range} &nbsp;·&nbsp; Move: {unit.move}</div>
+                    </button>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="summary-line">Waiting for battlefield data.</p>
+            )}
+          </section>
+        ) : null
+      ) : null}
+    </aside>
+  )
+}

--- a/web/components/BattlefieldRightRail.tsx
+++ b/web/components/BattlefieldRightRail.tsx
@@ -1,7 +1,9 @@
 import { CombatConfirmationView } from './CombatConfirmationView'
 import { CombatTargetList } from './CombatTargetList'
+import { InactiveEventStream } from './InactiveEventStream'
 import { parseAttackStats, parseWeaponStats } from '../lib/appViewHelpers'
 import type { BattlefieldOnionView, BattlefieldUnit } from '../lib/battlefieldView'
+import type { TimelineEvent } from '../lib/battlefieldView'
 import type { CombatTargetOption } from '../lib/combatPreview'
 
 type BattlefieldRightRailProps = {
@@ -15,6 +17,11 @@ type BattlefieldRightRailProps = {
   selectedCombatTargetId: string | null
   selectedInspectorDefender: BattlefieldUnit | null
   selectedInspectorOnion: BattlefieldOnionView | null
+  inactiveEventStream: {
+    entries: ReadonlyArray<TimelineEvent>
+    clearEntries: () => void
+    isDismissed: boolean
+  }
   combatTargetOptions: ReadonlyArray<CombatTargetOption>
   onConfirmCombat: () => void
   onSelectCombatTarget: (targetId: string) => void
@@ -31,12 +38,19 @@ export function BattlefieldRightRail({
   selectedCombatTargetId,
   selectedInspectorDefender,
   selectedInspectorOnion,
+  inactiveEventStream,
   combatTargetOptions,
   onConfirmCombat,
   onSelectCombatTarget,
 }: BattlefieldRightRailProps) {
   return (
     <aside className="panel rail rail-right">
+      {!inactiveEventStream.isDismissed ? (
+        <InactiveEventStream
+          entries={inactiveEventStream.entries}
+          onDismiss={inactiveEventStream.clearEntries}
+        />
+      ) : null}
       {selectedInspectorOnion !== null ? (
         <section className="selection-panel panel-subtle">
           <div className="selection-panel-header">

--- a/web/components/BattlefieldRightRail.tsx
+++ b/web/components/BattlefieldRightRail.tsx
@@ -1,0 +1,166 @@
+import { CombatConfirmationView } from './CombatConfirmationView'
+import { CombatTargetList } from './CombatTargetList'
+import { parseAttackStats, parseWeaponStats } from '../lib/appViewHelpers'
+import type { BattlefieldOnionView, BattlefieldUnit } from '../lib/battlefieldView'
+import type { CombatTargetOption } from '../lib/combatPreview'
+
+type BattlefieldRightRailProps = {
+  activeCombatRole: 'onion' | 'defender' | null
+  activeRole: 'onion' | 'defender' | null
+  activeSelectedUnitCount: number
+  isCombatPhase: boolean
+  selectedCombatAttackCount: number
+  selectedCombatAttackStrength: number
+  selectedCombatTarget: CombatTargetOption | null
+  selectedCombatTargetId: string | null
+  selectedInspectorDefender: BattlefieldUnit | null
+  selectedInspectorOnion: BattlefieldOnionView | null
+  combatTargetOptions: ReadonlyArray<CombatTargetOption>
+  onConfirmCombat: () => void
+  onSelectCombatTarget: (targetId: string) => void
+}
+
+export function BattlefieldRightRail({
+  activeCombatRole,
+  activeRole,
+  activeSelectedUnitCount,
+  isCombatPhase,
+  selectedCombatAttackCount,
+  selectedCombatAttackStrength,
+  selectedCombatTarget,
+  selectedCombatTargetId,
+  selectedInspectorDefender,
+  selectedInspectorOnion,
+  combatTargetOptions,
+  onConfirmCombat,
+  onSelectCombatTarget,
+}: BattlefieldRightRailProps) {
+  return (
+    <aside className="panel rail rail-right">
+      {selectedInspectorOnion !== null ? (
+        <section className="selection-panel panel-subtle">
+          <div className="selection-panel-header">
+            <div>
+              <p className="eyebrow">Inspector</p>
+              <h2>{selectedInspectorOnion.type}</h2>
+            </div>
+            <span className="mini-tag">Selected</span>
+          </div>
+          <dl className="inspector-grid inspector-grid-right">
+            <div>
+              <dt>Stack</dt>
+              <dd>1</dd>
+            </div>
+            <div>
+              <dt>Treads</dt>
+              <dd>{selectedInspectorOnion.treads}</dd>
+            </div>
+            <div>
+              <dt>Moves</dt>
+              <dd>{selectedInspectorOnion.movesRemaining}</dd>
+            </div>
+            <div>
+              <dt>Rams remaining</dt>
+              <dd>{selectedInspectorOnion.rams}</dd>
+            </div>
+            <div>
+              <dt>Weapons</dt>
+              <dd>{parseWeaponStats(selectedInspectorOnion.weapons ?? '').operationalWeapons}</dd>
+            </div>
+            <div>
+              <dt>Missiles</dt>
+              <dd>{parseWeaponStats(selectedInspectorOnion.weapons ?? '').operationalMissiles}</dd>
+            </div>
+          </dl>
+        </section>
+      ) : isCombatPhase && activeRole === activeCombatRole && (activeRole === 'defender' || selectedInspectorDefender === null) ? (
+        <section className="section-block panel-subtle">
+          <div className="card-head">
+            <div>
+              <p className="eyebrow">Combat</p>
+              <h2 title="Pick a target from the list. The list only includes targets currently in the active attack range.">
+                Valid Targets
+              </h2>
+            </div>
+            <span className="mini-tag">{combatTargetOptions.length} in range</span>
+          </div>
+          {selectedCombatTarget !== null ? (
+            <CombatConfirmationView
+              title={`Confirm attack on ${selectedCombatTarget.label}`}
+              attackStrength={selectedCombatAttackStrength}
+              defenseStrength={selectedCombatTarget.defense}
+              modifiers={selectedCombatTarget.modifiers}
+              confirmLabel="Resolve combat"
+              onConfirm={onConfirmCombat}
+              dataTestId="combat-confirmation-view"
+            />
+          ) : null}
+          {combatTargetOptions.length > 0 ? (
+            <CombatTargetList
+              targets={combatTargetOptions}
+              selectedTargetId={selectedCombatTargetId}
+              selectedCombatAttackCount={selectedCombatAttackCount}
+              onSelectTarget={onSelectCombatTarget}
+            />
+          ) : (
+            <p className="summary-line">No valid targets are currently in range.</p>
+          )}
+        </section>
+      ) : selectedInspectorDefender !== null ? (
+        <section className="selection-panel panel-subtle">
+          <div className="selection-panel-header">
+            <div>
+              <p className="eyebrow">Inspector</p>
+              <h2>{selectedInspectorDefender.type}</h2>
+            </div>
+            <span className="mini-tag">Selected</span>
+          </div>
+          <dl className="inspector-grid inspector-grid-right">
+            <div>
+              <dt>Stack</dt>
+              <dd>{selectedInspectorDefender.type === 'LittlePigs' ? selectedInspectorDefender.squads ?? 1 : 1}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{selectedInspectorDefender.status}</dd>
+            </div>
+            <div>
+              <dt>Damage</dt>
+              <dd>{parseAttackStats(selectedInspectorDefender.attack).damage}</dd>
+            </div>
+            <div>
+              <dt>Range</dt>
+              <dd>{parseAttackStats(selectedInspectorDefender.attack).range}</dd>
+            </div>
+            <div>
+              <dt>Move</dt>
+              <dd>{selectedInspectorDefender.move}</dd>
+            </div>
+            <div>
+              <dt>Selected</dt>
+              <dd>{activeSelectedUnitCount}</dd>
+            </div>
+          </dl>
+        </section>
+      ) : isCombatPhase ? (
+        <section className="selection-panel panel-subtle">
+          <div className="selection-panel-header">
+            <div>
+              <p className="eyebrow">Inspector</p>
+            </div>
+          </div>
+          <div className="empty-state">Select a unit on the map or in the rail to inspect it here.</div>
+        </section>
+      ) : (
+        <section className="selection-panel panel-subtle">
+          <div className="selection-panel-header">
+            <div>
+              <p className="eyebrow">Inspector</p>
+            </div>
+          </div>
+          <div className="empty-state">Select a unit on the map or in the rail to inspect it here.</div>
+        </section>
+      )}
+    </aside>
+  )
+}

--- a/web/components/BattlefieldStage.tsx
+++ b/web/components/BattlefieldStage.tsx
@@ -1,0 +1,66 @@
+import { HexMapBoard } from './HexMapBoard'
+import type { BattlefieldOnionView, BattlefieldUnit } from '../lib/battlefieldView'
+
+type BattlefieldStageProps = {
+  activePhase: string | null
+  activeTurnActive: boolean
+  defenders: BattlefieldUnit[]
+  onion: BattlefieldOnionView
+  scenarioMap: {
+    width: number
+    height: number
+    cells: Array<{ q: number; r: number }>
+    hexes: Array<{ q: number; r: number; t: number }>
+  }
+  selectedCombatTargetId: string | null
+  selectedUnitIds: string[]
+  combatRangeHexKeys: ReadonlySet<string>
+  combatTargetIds: ReadonlySet<string>
+  canSubmitMove: boolean
+  viewerRole: 'onion' | 'defender' | null
+  onDeselect: () => void
+  onMoveUnit: (unitId: string, to: { q: number; r: number }) => void
+  onSelectCombatTarget: (targetId: string) => void
+  onSelectUnit: (unitId: string, additive?: boolean) => void
+}
+
+export function BattlefieldStage({
+  activePhase,
+  activeTurnActive,
+  defenders,
+  onion,
+  scenarioMap,
+  selectedCombatTargetId,
+  selectedUnitIds,
+  combatRangeHexKeys,
+  combatTargetIds,
+  canSubmitMove,
+  viewerRole,
+  onDeselect,
+  onMoveUnit,
+  onSelectCombatTarget,
+  onSelectUnit,
+}: BattlefieldStageProps) {
+  return (
+    <section className="panel map-stage">
+      <div className="map-frame">
+        <HexMapBoard
+          scenarioMap={scenarioMap}
+          defenders={defenders}
+          onion={onion}
+          phase={activePhase}
+          viewerRole={viewerRole}
+          selectedUnitIds={selectedUnitIds}
+          selectedCombatTargetId={selectedCombatTargetId}
+          combatRangeHexKeys={combatRangeHexKeys}
+          combatTargetIds={combatTargetIds}
+          canSubmitMove={canSubmitMove && activeTurnActive}
+          onSelectUnit={onSelectUnit}
+          onSelectCombatTarget={onSelectCombatTarget}
+          onDeselect={onDeselect}
+          onMoveUnit={onMoveUnit}
+        />
+      </div>
+    </section>
+  )
+}

--- a/web/components/InactiveEventStream.tsx
+++ b/web/components/InactiveEventStream.tsx
@@ -1,0 +1,38 @@
+import type { TimelineEvent } from '../lib/battlefieldView'
+
+type InactiveEventStreamProps = {
+	entries: ReadonlyArray<TimelineEvent>
+	onDismiss: () => void
+}
+
+export function InactiveEventStream({ entries, onDismiss }: InactiveEventStreamProps) {
+	return (
+		<section className="panel panel-subtle inactive-event-stream" role="status" aria-live="polite" data-testid="inactive-event-stream">
+			<div className="inactive-event-stream-head">
+				<h3>Opponent’s Results</h3>
+				<button
+					className="inactive-event-stream-dismiss"
+					type="button"
+					onClick={onDismiss}
+					aria-label="Dismiss inactive event stream"
+				>
+					Dismiss
+				</button>
+			</div>
+
+			<ul className="inactive-event-stream-list">
+				{entries.length > 0 ? (
+					entries.map((entry) => (
+						<li key={entry.seq} className={`inactive-event-stream-entry tone-${entry.tone ?? 'normal'}`}>
+							<p className="summary-line">{entry.summary}</p>
+						</li>
+					))
+				) : (
+					<li className="inactive-event-stream-entry tone-normal">
+						<p className="summary-line">Waiting for remote actions.</p>
+					</li>
+				)}
+			</ul>
+		</section>
+	)
+}

--- a/web/lib/gameClient.ts
+++ b/web/lib/gameClient.ts
@@ -67,7 +67,7 @@ export type GameAction =
 export type GameEvent = {
 	seq: number
 	type: string
-	summary: string
+	summary?: string
 	timestamp: string
 }
 

--- a/web/lib/gameSessionTypes.ts
+++ b/web/lib/gameSessionTypes.ts
@@ -14,7 +14,7 @@
  * - `GameSessionViewState` is the snapshot consumed by React and test helpers.
  */
 
-import type { GameAction, GameClientSeamError, GameSessionContext, GameSnapshot } from './gameClient'
+import type { GameAction, GameClientSeamError, GameEvent, GameSessionContext, GameSnapshot } from './gameClient'
 
 /**
  * Live connection state reported to the session controller and UI.
@@ -102,6 +102,7 @@ export type UseGameSessionOptions = {
 export type GameRequestTransport = {
 	getState(gameId: number): Promise<{ snapshot: GameSnapshot; session: GameSessionContext }>
 	submitAction(gameId: number, action: GameAction): Promise<GameSnapshot>
+	pollEvents?(gameId: number, afterSeq: number): Promise<ReadonlyArray<GameEvent>>
 }
 
 /**

--- a/web/lib/httpGameClient.ts
+++ b/web/lib/httpGameClient.ts
@@ -302,7 +302,12 @@ function createHttpGameTransportRuntime(options: HttpGameClientOptions): {
 }
 
 export function createHttpGameRequestTransport(options: HttpGameClientOptions): GameRequestTransport {
-	return createHttpGameTransportRuntime(options).requestTransport
+	const { requestTransport, pollEvents } = createHttpGameTransportRuntime(options)
+
+	return {
+		...requestTransport,
+		pollEvents,
+	}
 }
 
 export function createHttpGameClient(options: HttpGameClientOptions): GameClient {

--- a/web/lib/useBattlefieldDisplayState.ts
+++ b/web/lib/useBattlefieldDisplayState.ts
@@ -66,7 +66,7 @@ export function useBattlefieldDisplayState({
     const activePhaseLabel = activePhase === null ? 'WAITING' : turnPhaseLabels[activePhase]
     const activeMode: Mode = clientSnapshot?.mode ?? 'fire'
     const isCombatPhase = activePhase === 'ONION_COMBAT' || activePhase === 'DEFENDER_COMBAT'
-    const activeCombatRole = activePhase === null ? null : activePhase.startsWith('ONION_') ? 'onion' : activePhase.startsWith('DEFENDER_') ? 'defender' : null
+    const activeCombatRole: 'onion' | 'defender' | null = activePhase === null ? null : activePhase.startsWith('ONION_') ? 'onion' : activePhase.startsWith('DEFENDER_') ? 'defender' : null
     const isMovementPhase = activePhase === 'ONION_MOVE' || activePhase === 'DEFENDER_MOVE' || activePhase === 'GEV_SECOND_MOVE'
     const displayedScenarioMap = buildScenarioMap(clientSnapshot)
     const selectedCombatAttackerIds = !isCombatPhase

--- a/web/lib/useConnectionGate.ts
+++ b/web/lib/useConnectionGate.ts
@@ -34,6 +34,14 @@ export function useConnectionGate({ runtimeConfig, onConnectedSession }: UseConn
   async function submitConnectDraft(draft: ConnectDraft) {
     setConnectError(null)
 
+    if (typeof window !== 'undefined') {
+      console.info('[connection-gate] submit', {
+        apiBaseUrl: draft.apiBaseUrl,
+        username: draft.username,
+        gameId: draft.gameId,
+      })
+    }
+
     if (!draft.apiBaseUrl.trim() || !draft.username.trim() || !draft.password.trim() || !draft.gameId.trim()) {
       setConnectError('API base URL, username, password, and game ID are required.')
       return
@@ -62,6 +70,13 @@ export function useConnectionGate({ runtimeConfig, onConnectedSession }: UseConn
       }
 
       const baseUrl = draft.apiBaseUrl.trim()
+      if (typeof window !== 'undefined') {
+        console.info('[connection-gate] connected session created', {
+          gameId: parsedGameId,
+          baseUrl,
+          username: loginResult.data.userId,
+        })
+      }
       onConnectedSession({
         requestTransport: createHttpGameRequestTransport({
           baseUrl,

--- a/web/lib/useInactiveEventStream.ts
+++ b/web/lib/useInactiveEventStream.ts
@@ -11,20 +11,7 @@ type UseInactiveEventStreamOptions = {
 	pollEvents?: GameRequestTransport['pollEvents']
 }
 
-function formatEventTitle(type: string) {
-	switch (type) {
-		case 'FIRE_RESOLVED':
-			return 'Combat attempt'
-		case 'MOVE_RESOLVED':
-			return 'Ram resolved'
-		case 'UNIT_STATUS_CHANGED':
-			return 'Unit status changed'
-		case 'PHASE_CHANGED':
-			return 'Phase changed'
-		default:
-			return type.replace(/_/g, ' ').toLowerCase()
-	}
-}
+
 function formatEventSummary(event: GameEvent) {
 	if (typeof event.summary === 'string' && event.summary.trim().length > 0) {
 		return event.summary
@@ -75,7 +62,12 @@ export function useInactiveEventStream({
 	}, [activeGameId])
 
 	useEffect(() => {
-		if (lastAppliedEventSeq === null || activeTurnActive || activeGameId === null || pollEvents === undefined) {
+		if (
+			lastAppliedEventSeq === null ||
+			activeTurnActive ||
+			activeGameId === null ||
+			pollEvents === undefined
+		) {
 			return
 		}
 
@@ -94,10 +86,14 @@ export function useInactiveEventStream({
 		inFlightAfterSeqRef.current = afterSeq
 
 		async function loadEvents() {
+			// Guard pollEvents and arguments
+			if (pollEvents === undefined || activeGameId === null) {
+				return undefined
+			}
 			try {
-				const events = await pollEvents(activeGameId, afterSeq)
+				const events = await pollEvents(Number(activeGameId), Number(afterSeq))
 				if (cancelled) {
-					return
+					return undefined
 				}
 
 				const unseenEvents = events.filter((event) => !seenSeqsRef.current.has(event.seq))
@@ -115,7 +111,8 @@ export function useInactiveEventStream({
 				}
 
 				const maxReturnedSeq = events.reduce((maxSeq, event) => Math.max(maxSeq, event.seq), afterSeq)
-				loadedThroughSeqRef.current = Math.max(maxReturnedSeq, lastAppliedEventSeq)
+				// Default lastAppliedEventSeq to 0 if null
+				loadedThroughSeqRef.current = Math.max(maxReturnedSeq, lastAppliedEventSeq ?? 0)
 			} catch {
 				// Keep the existing stream in place; the next live hint can retry.
 			} finally {
@@ -132,7 +129,6 @@ export function useInactiveEventStream({
 				) {
 					queuedRefreshRef.current = false
 					void loadEvents()
-					return
 				}
 
 				queuedRefreshRef.current = false

--- a/web/lib/useInactiveEventStream.ts
+++ b/web/lib/useInactiveEventStream.ts
@@ -25,41 +25,9 @@ function formatEventTitle(type: string) {
 			return type.replace(/_/g, ' ').toLowerCase()
 	}
 }
-
 function formatEventSummary(event: GameEvent) {
 	if (typeof event.summary === 'string' && event.summary.trim().length > 0) {
 		return event.summary
-	}
-
-	if (event.type === 'FIRE_RESOLVED') {
-		const attackers = Array.isArray(event.attackers) ? event.attackers.join(', ') : 'Unknown attackers'
-		const targetId = typeof event.targetId === 'string' ? event.targetId : 'unknown target'
-		const outcome = typeof event.outcome === 'string' ? event.outcome : 'resolved'
-		const roll = typeof event.roll === 'number' ? ` roll ${event.roll}` : ''
-		const odds = typeof event.odds === 'string' ? ` at ${event.odds}` : ''
-		return `${attackers} fired at ${targetId}${odds}${roll} (${outcome}).`
-	}
-
-	if (event.type === 'MOVE_RESOLVED') {
-		const unitId = typeof event.unitId === 'string' ? event.unitId : 'Unknown unit'
-		const rammed = Array.isArray(event.rammedUnitIds) && event.rammedUnitIds.length > 0 ? event.rammedUnitIds.join(', ') : 'no units'
-		const destroyed = Array.isArray(event.destroyedUnitIds) && event.destroyedUnitIds.length > 0 ? event.destroyedUnitIds.join(', ') : 'none'
-		const treadDamage = typeof event.treadDamage === 'number' ? event.treadDamage : 0
-		return `${unitId} rammed ${rammed}; destroyed ${destroyed}; tread damage ${treadDamage}.`
-	}
-
-	if (event.type === 'UNIT_STATUS_CHANGED') {
-		const unitId = typeof event.unitId === 'string' ? event.unitId : 'Unknown unit'
-		const from = typeof event.from === 'string' ? event.from : 'unknown'
-		const to = typeof event.to === 'string' ? event.to : 'unknown'
-		return `${unitId} changed status from ${from} to ${to}.`
-	}
-
-	if (event.type === 'PHASE_CHANGED') {
-		const from = typeof event.from === 'string' ? event.from : 'unknown'
-		const to = typeof event.to === 'string' ? event.to : 'unknown'
-		const turnNumber = typeof event.turnNumber === 'number' ? ` on turn ${event.turnNumber}` : ''
-		return `Phase changed from ${from} to ${to}${turnNumber}.`
 	}
 
 	return event.type.replace(/_/g, ' ').toLowerCase()
@@ -86,7 +54,13 @@ export function useInactiveEventStream({
 	const seenSeqsRef = useRef(new Set<number>())
 	const loadedThroughSeqRef = useRef<number | null>(null)
 	const inFlightAfterSeqRef = useRef<number | null>(null)
+	const latestAppliedEventSeqRef = useRef<number | null>(lastAppliedEventSeq)
+	const queuedRefreshRef = useRef(false)
 	const lastGameIdRef = useRef<number | null>(null)
+
+	useEffect(() => {
+		latestAppliedEventSeqRef.current = lastAppliedEventSeq
+	}, [lastAppliedEventSeq])
 
 	useEffect(() => {
 		if (lastGameIdRef.current !== activeGameId) {
@@ -96,6 +70,7 @@ export function useInactiveEventStream({
 			seenSeqsRef.current = new Set<number>()
 			loadedThroughSeqRef.current = null
 			inFlightAfterSeqRef.current = null
+			queuedRefreshRef.current = false
 		}
 	}, [activeGameId])
 
@@ -111,6 +86,7 @@ export function useInactiveEventStream({
 
 		const afterSeq = loadedThroughSeq ?? 0
 		if (inFlightAfterSeqRef.current === afterSeq) {
+			queuedRefreshRef.current = true
 			return
 		}
 
@@ -146,6 +122,20 @@ export function useInactiveEventStream({
 				if (inFlightAfterSeqRef.current === afterSeq) {
 					inFlightAfterSeqRef.current = null
 				}
+
+				if (
+					!cancelled &&
+					queuedRefreshRef.current &&
+					latestAppliedEventSeqRef.current !== null &&
+					loadedThroughSeqRef.current !== null &&
+					loadedThroughSeqRef.current < latestAppliedEventSeqRef.current
+				) {
+					queuedRefreshRef.current = false
+					void loadEvents()
+					return
+				}
+
+				queuedRefreshRef.current = false
 			}
 		}
 

--- a/web/lib/useInactiveEventStream.ts
+++ b/web/lib/useInactiveEventStream.ts
@@ -1,0 +1,172 @@
+import { useEffect, useRef, useState } from 'react'
+
+import type { TimelineEvent } from './battlefieldView'
+import type { GameEvent } from './gameClient'
+import type { GameRequestTransport } from './gameSessionTypes'
+
+type UseInactiveEventStreamOptions = {
+	activeGameId: number | null
+	activeTurnActive: boolean
+	lastAppliedEventSeq: number | null
+	pollEvents?: GameRequestTransport['pollEvents']
+}
+
+function formatEventTitle(type: string) {
+	switch (type) {
+		case 'FIRE_RESOLVED':
+			return 'Combat attempt'
+		case 'MOVE_RESOLVED':
+			return 'Ram resolved'
+		case 'UNIT_STATUS_CHANGED':
+			return 'Unit status changed'
+		case 'PHASE_CHANGED':
+			return 'Phase changed'
+		default:
+			return type.replace(/_/g, ' ').toLowerCase()
+	}
+}
+
+function formatEventSummary(event: GameEvent) {
+	if (typeof event.summary === 'string' && event.summary.trim().length > 0) {
+		return event.summary
+	}
+
+	if (event.type === 'FIRE_RESOLVED') {
+		const attackers = Array.isArray(event.attackers) ? event.attackers.join(', ') : 'Unknown attackers'
+		const targetId = typeof event.targetId === 'string' ? event.targetId : 'unknown target'
+		const outcome = typeof event.outcome === 'string' ? event.outcome : 'resolved'
+		const roll = typeof event.roll === 'number' ? ` roll ${event.roll}` : ''
+		const odds = typeof event.odds === 'string' ? ` at ${event.odds}` : ''
+		return `${attackers} fired at ${targetId}${odds}${roll} (${outcome}).`
+	}
+
+	if (event.type === 'MOVE_RESOLVED') {
+		const unitId = typeof event.unitId === 'string' ? event.unitId : 'Unknown unit'
+		const rammed = Array.isArray(event.rammedUnitIds) && event.rammedUnitIds.length > 0 ? event.rammedUnitIds.join(', ') : 'no units'
+		const destroyed = Array.isArray(event.destroyedUnitIds) && event.destroyedUnitIds.length > 0 ? event.destroyedUnitIds.join(', ') : 'none'
+		const treadDamage = typeof event.treadDamage === 'number' ? event.treadDamage : 0
+		return `${unitId} rammed ${rammed}; destroyed ${destroyed}; tread damage ${treadDamage}.`
+	}
+
+	if (event.type === 'UNIT_STATUS_CHANGED') {
+		const unitId = typeof event.unitId === 'string' ? event.unitId : 'Unknown unit'
+		const from = typeof event.from === 'string' ? event.from : 'unknown'
+		const to = typeof event.to === 'string' ? event.to : 'unknown'
+		return `${unitId} changed status from ${from} to ${to}.`
+	}
+
+	if (event.type === 'PHASE_CHANGED') {
+		const from = typeof event.from === 'string' ? event.from : 'unknown'
+		const to = typeof event.to === 'string' ? event.to : 'unknown'
+		const turnNumber = typeof event.turnNumber === 'number' ? ` on turn ${event.turnNumber}` : ''
+		return `Phase changed from ${from} to ${to}${turnNumber}.`
+	}
+
+	return event.type.replace(/_/g, ' ').toLowerCase()
+}
+
+function toTimelineEvent(event: GameEvent): TimelineEvent {
+	return {
+		seq: event.seq,
+		type: event.type,
+		summary: formatEventSummary(event),
+		timestamp: event.timestamp,
+		tone: event.type === 'UNIT_STATUS_CHANGED' || event.type === 'PHASE_CHANGED' ? 'alert' : 'normal',
+	}
+}
+
+export function useInactiveEventStream({
+	activeGameId,
+	activeTurnActive,
+	lastAppliedEventSeq,
+	pollEvents,
+}: UseInactiveEventStreamOptions) {
+	const [entries, setEntries] = useState<TimelineEvent[]>([])
+	const [isDismissed, setIsDismissed] = useState(false)
+	const seenSeqsRef = useRef(new Set<number>())
+	const loadedThroughSeqRef = useRef<number | null>(null)
+	const inFlightAfterSeqRef = useRef<number | null>(null)
+	const lastGameIdRef = useRef<number | null>(null)
+
+	useEffect(() => {
+		if (lastGameIdRef.current !== activeGameId) {
+			lastGameIdRef.current = activeGameId
+			setEntries([])
+			setIsDismissed(false)
+			seenSeqsRef.current = new Set<number>()
+			loadedThroughSeqRef.current = null
+			inFlightAfterSeqRef.current = null
+		}
+	}, [activeGameId])
+
+	useEffect(() => {
+		if (lastAppliedEventSeq === null || activeTurnActive || activeGameId === null || pollEvents === undefined) {
+			return
+		}
+
+		const loadedThroughSeq = loadedThroughSeqRef.current
+		if (loadedThroughSeq !== null && lastAppliedEventSeq <= loadedThroughSeq) {
+			return
+		}
+
+		const afterSeq = loadedThroughSeq ?? 0
+		if (inFlightAfterSeqRef.current === afterSeq) {
+			return
+		}
+
+		let cancelled = false
+		inFlightAfterSeqRef.current = afterSeq
+
+		async function loadEvents() {
+			try {
+				const events = await pollEvents(activeGameId, afterSeq)
+				if (cancelled) {
+					return
+				}
+
+				const unseenEvents = events.filter((event) => !seenSeqsRef.current.has(event.seq))
+				for (const event of unseenEvents) {
+					seenSeqsRef.current.add(event.seq)
+				}
+
+				if (unseenEvents.length > 0) {
+					setEntries((currentEntries) => {
+						const nextEntries = currentEntries.concat(unseenEvents.map(toTimelineEvent))
+						nextEntries.sort((left, right) => left.seq - right.seq)
+						return nextEntries
+					})
+					setIsDismissed(false)
+				}
+
+				const maxReturnedSeq = events.reduce((maxSeq, event) => Math.max(maxSeq, event.seq), afterSeq)
+				loadedThroughSeqRef.current = Math.max(maxReturnedSeq, lastAppliedEventSeq)
+			} catch {
+				// Keep the existing stream in place; the next live hint can retry.
+			} finally {
+				if (inFlightAfterSeqRef.current === afterSeq) {
+					inFlightAfterSeqRef.current = null
+				}
+			}
+		}
+
+		void loadEvents()
+
+		return () => {
+			cancelled = true
+			if (inFlightAfterSeqRef.current === afterSeq) {
+				inFlightAfterSeqRef.current = null
+			}
+		}
+	}, [activeGameId, activeTurnActive, lastAppliedEventSeq, pollEvents])
+
+	function clearEntries() {
+		setEntries([])
+		setIsDismissed(true)
+	}
+
+	return {
+		clearEntries,
+		entries,
+		isDismissed,
+	}
+}


### PR DESCRIPTION
This PR implements the full Opponent’s Results (formerly passive toasts) feature for the Onion project, covering both backend and frontend, with a focus on reviewable, deduplicated, and user-friendly event history for the inactive player.

**Summary of efforts in this thread:**
- Refined the original passive notification concept into a reviewable, dismissible event stream for the non-active player, now called "Opponent’s Results".
- Updated the project TODO and feature checklist to clarify requirements, event types, and deduplication policy.
- Implemented the event stream contract in the backend and ensured all relevant events (combat, ram, unit destruction, phase changes) are emitted and persisted.
- Extended the frontend transport and session controller to support polling and live event delivery, with proper seq-based deduplication and history loading.
- Added a new right-rail UI panel for "Opponent’s Results" with a compact, scrollable, and dismissible design, showing only new events since last viewed.
- Streamlined the event entry format to a single-line summary per event, removing redundant type and id display for clarity.
- Added and updated focused UI and transport tests to cover all new behaviors, including dismissal, deduplication, and historical event loading.
- Refactored and cleaned up related files, including test plumbing, transport contracts, and the project TODO.
- Moved the entire epic and all subtasks to Done in the TODO, with backend and UI coverage complete.

This PR closes the Opponent’s Results epic and delivers a robust, user-friendly event stream for the inactive player experience.

---

**Please review:**
- UI/UX of the right-rail event stream
- Backend event emission coverage
- Test coverage for edge cases (reconnect, dismissal, history)
- Code structure and maintainability

Ready for review and merge.