### PR TITLE
Add causeId event grouping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,8 @@
         "git checkout": true,
         "git -C /home/zymurge/Dev/onion": true,
         "printf": true,
-        "docker compose": true
+        "docker compose": true,
+        "git merge": true
     },
     "github.copilot.chat.cli.forkSessions.enabled": true,
     "npm.scriptRunner": "pnpm"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Create PR using GitHub Pull Request Extension",
+			"type": "shell",
+			"command": "echo 'PR creation requested via GitHub Pull Request Extension. Please use the extension UI to finalize.'",
+			"group": "build"
+		}
+	]
+}

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -18,6 +18,7 @@ break down into features/tasks as needed.
 
 - [ ] Replace the debug protocol viewer with `@uiw/react-json-view` and add custom expansion shortcuts for deep-dive trees (for example: double-click subtree expand/collapse and expand-all controls).
 - [ ] Make client side logging verbosity level sensitive; move existing console logs to proper levels.
+- [ ] Create friendly names for all units and Onion weapons to be used for user facing messaging instead of ids.
 
 ## Done
 

--- a/docs/web-ui-spec.md
+++ b/docs/web-ui-spec.md
@@ -85,11 +85,11 @@ Primary backend endpoints used by the web client:
 
 - The right rail must always display the inactive events stream during non-active phases, updating in real time from server events.
 - The stream is visually distinct, non-blocking, and accessible, with clear summaries and error overlays.
-- All event summaries are type-safe, concise, and support expansion for details.
+- All event summaries are concise and derived defensively from event payload data, with additional details exposed through accessible DOM disclosure.
 - The stream must handle both polling and WebSocket updates, with robust error and reconnection handling.
 - All errors (API, network, parsing) must be surfaced as dismissible overlays, not as blocking modals or content shifts.
 - The stream is ordered chronologically and filters out events already surfaced in the main action area, showing only those relevant to the inactive player or phase.
-- Users can scroll through the event stream, expand/collapse details, and dismiss error overlays.
+- Users can scroll through the event stream, inspect additional details through disclosure controls, and dismiss error overlays.
 - Show a spinner or placeholder when loading, and a friendly message when no inactive events are present.
 - All event summaries and controls must be keyboard-navigable and screen-reader friendly.
 - The stream updates in real time as new events arrive, with smooth transitions and no jarring UI shifts.

--- a/docs/web-ui-spec.md
+++ b/docs/web-ui-spec.md
@@ -78,6 +78,22 @@ Primary backend endpoints used by the web client:
 - In Onion combat, the rail shows Onion weapons eligible to attack.
 - In Defender combat, the rail shows defender units eligible to attack.
 - Onion combat board clicks do not add attackers; weapon selection comes from the rail.
+
+---
+
+### Inactive Events Stream (Right Rail)
+
+- The right rail must always display the inactive events stream during non-active phases, updating in real time from server events.
+- The stream is visually distinct, non-blocking, and accessible, with clear summaries and error overlays.
+- All event summaries are type-safe, concise, and support expansion for details.
+- The stream must handle both polling and WebSocket updates, with robust error and reconnection handling.
+- All errors (API, network, parsing) must be surfaced as dismissible overlays, not as blocking modals or content shifts.
+- The stream is ordered chronologically and filters out events already surfaced in the main action area, showing only those relevant to the inactive player or phase.
+- Users can scroll through the event stream, expand/collapse details, and dismiss error overlays.
+- Show a spinner or placeholder when loading, and a friendly message when no inactive events are present.
+- All event summaries and controls must be keyboard-navigable and screen-reader friendly.
+- The stream updates in real time as new events arrive, with smooth transitions and no jarring UI shifts.
+- All UI behaviors must be covered by regression tests, including event arrival, error handling, and accessibility.
 - Destroyed defender units remain visible for context, are greyed out, sorted to the bottom of the defender list, and cannot be selected as attackers.
 
 ### Targeting and Confirmation

--- a/server/api/games.ts
+++ b/server/api/games.ts
@@ -85,6 +85,13 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
     }
   }
 
+  function attachCauseId(events: EventEnvelope[], causeId: string): EventEnvelope[] {
+    return events.map((event) => ({
+      ...event,
+      causeId,
+    }))
+  }
+
   function removeLiveConnection(gameId: number, socket: WebSocket) {
     const sockets = liveConnections.get(gameId)
     if (!sockets) {
@@ -220,6 +227,7 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
       logger.info({ gameId: match.gameId, role }, 'User joined game')
 
       // Emit PLAYER_JOINED event
+      const causeId = String(req.id)
       const seq = (match.events.at(-1)?.seq ?? 0) + 1
       const event = {
         seq,
@@ -228,8 +236,9 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
         userId,
         role,
       }
-      await db.appendEvents(match.gameId, [event])
-      broadcastGameEvents(match.gameId, [event])
+      const taggedEvent = { ...event, causeId }
+      await db.appendEvents(match.gameId, [taggedEvent])
+      broadcastGameEvents(match.gameId, [taggedEvent])
       logger.debug({ gameId: match.gameId, event }, 'PLAYER_JOINED event appended')
 
       return reply.send({ gameId: match.gameId, role })
@@ -498,11 +507,12 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
       let newEvents: EventEnvelope[]
       let currentState = match.state
       const expectedLastEventSeq = match.events.at(-1)?.seq ?? 0
+      const causeId = String(req.id)
 
       if (command.type === 'END_PHASE') {
         logger.info({ gameId: match.gameId, phase: match.phase }, 'Advancing phase')
         const result = advancePhaseWithEvents(match)
-        newEvents = result.newEvents
+        newEvents = attachCauseId(result.newEvents, causeId)
         currentState = result.state
         const winner = computeWinnerUserId(match, result.state, result.phase, result.turnNumber) ?? match.winner
         await db.persistMatchProgress({
@@ -545,7 +555,7 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
         }
 
         const nextSeq = (match.events.at(-1)?.seq ?? 0) + 1
-        newEvents = buildMoveEvents(nextSeq, validation.plan.unitId, command, result, state)
+        newEvents = attachCauseId(buildMoveEvents(nextSeq, validation.plan.unitId, command, result, state), causeId)
 
         currentState = state
         const winner = computeWinnerUserId(match, state, match.phase, match.turnNumber) ?? match.winner
@@ -598,7 +608,7 @@ export const gameRoutes: FastifyPluginAsync<{ db: DbAdapter }> = async (app: Fas
         }
 
         const seq = (match.events.at(-1)?.seq ?? 0) + 1
-        newEvents = buildCombatEvents(seq, command, result, state)
+        newEvents = attachCauseId(buildCombatEvents(seq, command, result, state), causeId)
         currentState = state
         const winner = computeWinnerUserId(match, state, match.phase, match.turnNumber) ?? match.winner
         await db.persistMatchProgress({

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -69,6 +69,7 @@ export interface EventEnvelope {
   seq: number
   type: string
   timestamp: string
+  causeId?: string
   [key: string]: unknown
 }
 

--- a/test/server/api/games.actions.combat.test.ts
+++ b/test/server/api/games.actions.combat.test.ts
@@ -223,6 +223,8 @@ describe('POST /games/:id/actions combat API contract', () => {
     expect(body.events[1].type).toBe('ONION_TREADS_LOST')
     expect(body.events[1].amount).toBe(2)
     expect(body.events[1].remaining).toBe(43)
+    expect(body.events[0].causeId).toBeDefined()
+    expect(body.events.every((event: any) => event.causeId === body.events[0].causeId)).toBe(true)
     expect(body.state.onion.treads).toBe(43)
     expect(infoSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -293,6 +295,8 @@ describe('POST /games/:id/actions combat API contract', () => {
     expect(body.events[1].type).toBe('ONION_BATTERY_DESTROYED')
     expect(body.events[1].weaponId).toBe('main')
     expect(body.events[1].weaponType).toBe('main')
+    expect(body.events[0].causeId).toBeDefined()
+    expect(body.events.every((event: any) => event.causeId === body.events[0].causeId)).toBe(true)
     validateSpy.mockRestore()
     executeSpy.mockRestore()
   })

--- a/test/server/api/games.actions.move.test.ts
+++ b/test/server/api/games.actions.move.test.ts
@@ -302,6 +302,8 @@ describe('POST /games/:id/actions MOVE', () => {
     expect(eventTypes[1]).toBe('MOVE_RESOLVED')
     expect(eventTypes).toContain('ONION_TREADS_LOST')
     expect(eventTypes).toContain('UNIT_STATUS_CHANGED')
+    expect(body.events[0].causeId).toBeDefined()
+    expect(body.events.every((event: any) => event.causeId === body.events[0].causeId)).toBe(true)
 
     const ramEvent = body.events.find((e: any) => e.type === 'MOVE_RESOLVED')
     expect(ramEvent.rammedUnitIds).toEqual(['d1'])
@@ -367,6 +369,8 @@ describe('POST /games/:id/actions MOVE', () => {
     expect(eventTypes[1]).toBe('MOVE_RESOLVED')
     expect(eventTypes).toContain('ONION_TREADS_LOST')
     expect(eventTypes).not.toContain('UNIT_STATUS_CHANGED')
+    expect(body.events[0].causeId).toBeDefined()
+    expect(body.events.every((event: any) => event.causeId === body.events[0].causeId)).toBe(true)
 
     const ramEvent = body.events.find((e: any) => e.type === 'MOVE_RESOLVED')
     expect(ramEvent.rammedUnitIds).toEqual(['d1'])

--- a/test/server/api/games.actions.phase.test.ts
+++ b/test/server/api/games.actions.phase.test.ts
@@ -27,6 +27,8 @@ describe('POST /games/:id/actions END_PHASE', () => {
       to: 'ONION_COMBAT',
       turnNumber: 1,
     })
+    expect(body.events[0].causeId).toBeDefined()
+    expect(body.events.every((event: any) => event.causeId === body.events[0].causeId)).toBe(true)
     expect(body.turnNumber).toBe(1)
     expect(body.eventSeq).toBe(body.seq)
     expect(body).toHaveProperty('state')
@@ -96,6 +98,7 @@ describe('POST /games/:id/actions END_PHASE', () => {
 
     expect(events.some((event) => event.type === 'PHASE_CHANGED')).toBe(true)
     expect(events.at(-1)?.seq).toBe(actionBody.eventSeq)
+    expect(actionBody.events.every((event: any) => event.causeId === actionBody.events[0].causeId)).toBe(true)
   })
 
   it('returns 403 when submitting on opponent turn', async () => {

--- a/test/server/api/games.actions.phase.test.ts
+++ b/test/server/api/games.actions.phase.test.ts
@@ -92,7 +92,7 @@ describe('POST /games/:id/actions END_PHASE', () => {
     await joinGame(app, gameId, fiona.token)
 
     const action = await endPhase(app, gameId, shrek.token)
-    const actionBody = action.json<{ eventSeq: number }>()
+    const actionBody = action.json<{ eventSeq: number; events: Array<{ seq: number; causeId?: string }> }>()
     const eventsRes = await getEvents(app, gameId, shrek.token)
     const events = eventsRes.json<{ events: Array<{ seq: number; type: string }> }>().events
 

--- a/test/server/api/games.state.test.ts
+++ b/test/server/api/games.state.test.ts
@@ -174,7 +174,7 @@ describe('GET /games/:id/events', () => {
     const res = await getEvents(app, gameId, shrek.token)
 
     expect(res.statusCode).toBe(200)
-    const { events } = res.json<{ events: { seq: number; type: string; userId: string; role: string }[] }>()
+    const { events } = res.json<{ events: { seq: number; type: string; userId: string; role: string; causeId?: string }[] }>()
     const joinEvent = events.find((event) => event.type === 'PLAYER_JOINED')
     expect(joinEvent).toBeDefined()
     expect(joinEvent?.userId).toBeDefined()

--- a/test/server/api/games.state.test.ts
+++ b/test/server/api/games.state.test.ts
@@ -179,5 +179,6 @@ describe('GET /games/:id/events', () => {
     expect(joinEvent).toBeDefined()
     expect(joinEvent?.userId).toBeDefined()
     expect(['onion', 'defender']).toContain(joinEvent?.role)
+    expect(joinEvent?.causeId).toBeDefined()
   })
 })

--- a/test/web/app/ui/App.ui.test.tsx
+++ b/test/web/app/ui/App.ui.test.tsx
@@ -598,6 +598,136 @@ describe('App UI', () => {
 		expect(pollEvents).toHaveBeenCalledWith(123, 48)
 	})
 
+	it('surfaces a non-blocking error when inactive-event polling fails', async () => {
+		const snapshot = createOnionMoveSnapshot(null, 4)
+		const liveEventSource = createLiveEventSourceStub()
+		const pollEvents = vi.fn().mockRejectedValue(new Error('network down'))
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session: { role: 'defender' as const } }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents,
+		})
+
+		render(<App gameClient={client} gameId={123} liveEventSource={liveEventSource as LiveEventSource} />)
+
+		expect(await screen.findByTestId('inactive-event-stream')).not.toBeNull()
+		expect(screen.getByRole('alert')).not.toBeNull()
+		expect(screen.getByText(/unable to refresh inactive events/i)).not.toBeNull()
+		expect(pollEvents).toHaveBeenCalledWith(123, 0)
+	})
+
+	it('hides the inactive-event stream after the session becomes active again', async () => {
+		const user = userEvent.setup()
+		const inactiveSnapshot = createOnionMoveSnapshot(null, 4)
+		const activeSnapshot = createDefenderMoveSnapshotWithZeroMa()
+		const liveEventSource = createLiveEventSourceStub()
+		const getState = vi
+			.fn()
+			.mockResolvedValueOnce({ snapshot: inactiveSnapshot, session: { role: 'defender' as const } })
+			.mockResolvedValue({ snapshot: activeSnapshot, session: { role: 'defender' as const } })
+		const client = createGameClient({
+			getState,
+			submitAction: vi.fn().mockResolvedValue(activeSnapshot),
+			pollEvents: vi.fn().mockResolvedValue([]),
+		})
+
+		render(<App gameClient={client} gameId={123} liveEventSource={liveEventSource as LiveEventSource} />)
+
+		expect(await screen.findByTestId('inactive-event-stream')).not.toBeNull()
+		expect(screen.getByText(/Waiting for remote actions\./i)).not.toBeNull()
+
+		await user.click(screen.getByRole('button', { name: /refresh/i }))
+
+		await waitFor(() => {
+			expect(screen.queryByTestId('inactive-event-stream')).toBeNull()
+		})
+		expect(getState).toHaveBeenCalledWith(123)
+	})
+
+	it('renders structured inactive-event summaries when summary text is absent', async () => {
+		const snapshot = createOnionMoveSnapshot(null, 4)
+		const liveEventSource = createLiveEventSourceStub()
+		const pollEvents = vi.fn().mockResolvedValue([
+			{
+				seq: 52,
+				type: 'PHASE_CHANGED',
+				timestamp: '2026-04-15T12:02:00.000Z',
+				from: 'ONION_MOVE',
+				to: 'DEFENDER_COMBAT',
+			},
+			{
+				seq: 53,
+				type: 'SESSION_CONNECTED',
+				timestamp: '2026-04-15T12:02:30.000Z',
+				summary: 'Defender connected to the session.',
+			},
+			{
+				seq: 54,
+				type: 'UNIT_MOVED',
+				timestamp: '2026-04-15T12:03:00.000Z',
+				unitId: 'wolf-2',
+				to: { q: 3, r: 4 },
+			},
+			{
+				seq: 55,
+				type: 'MOVE_RESOLVED',
+				timestamp: '2026-04-15T12:03:01.000Z',
+				unitId: 'wolf-2',
+				rammedUnitIds: ['pigs-1'],
+				destroyedUnitIds: ['pigs-1'],
+				treadDamage: 1,
+			},
+			{
+				seq: 56,
+				type: 'FIRE_RESOLVED',
+				timestamp: '2026-04-15T12:04:00.000Z',
+				attackers: ['wolf-2'],
+				targetId: 'pigs-1',
+				roll: 5,
+				outcome: 'X',
+				odds: '2:1',
+			},
+			{
+				seq: 57,
+				type: 'ONION_TREADS_LOST',
+				timestamp: '2026-04-15T12:04:01.000Z',
+				amount: 2,
+				remaining: 43,
+			},
+			{
+				seq: 58,
+				type: 'UNIT_STATUS_CHANGED',
+				timestamp: '2026-04-15T12:04:02.000Z',
+				unitId: 'pigs-1',
+				from: 'operational',
+				to: 'destroyed',
+			},
+		])
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session: { role: 'defender' as const } }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents,
+		})
+
+		render(<App gameClient={client} gameId={123} liveEventSource={liveEventSource as LiveEventSource} />)
+
+		expect(await screen.findByText(/ram attempt by wolf-2/i)).not.toBeNull()
+		expect(screen.getByText(/fire on pigs-1: result x/i)).not.toBeNull()
+		expect(screen.queryByText(/phase changed/i)).toBeNull()
+		expect(screen.queryByText(/defender connected to the session/i)).toBeNull()
+
+		const stream = screen.getByTestId('inactive-event-stream')
+		expect(stream.querySelectorAll('.inactive-event-stream-entry').length).toBe(2)
+		const entries = Array.from(stream.querySelectorAll('.inactive-event-stream-entry'))
+		expect(entries[0].getAttribute('title')).toContain('wolf-2 moved to (3, 4)')
+		expect(entries[0].getAttribute('title')).toContain('Rammed units: pigs-1')
+		expect(entries[0].getAttribute('title')).toContain('Tread loss: 1')
+		expect(entries[1].getAttribute('title')).toContain('Attackers: wolf-2')
+		expect(entries[1].getAttribute('title')).toContain('Outcome: X')
+		expect(entries[1].getAttribute('title')).toContain('Treads lost: 2')
+		expect(entries[1].getAttribute('title')).toContain('Unit pigs-1: operational → destroyed')
+	})
+
 	it('preserves debug popup position and size when toggled closed and reopened', async () => {
 		const user = userEvent.setup()
 		render(<App />)

--- a/test/web/app/ui/App.ui.test.tsx
+++ b/test/web/app/ui/App.ui.test.tsx
@@ -644,7 +644,49 @@ describe('App UI', () => {
 		expect(getState).toHaveBeenCalledWith(123)
 	})
 
+	it('clears stale inactive-event errors after polling is disabled and resumes cleanly', async () => {
+		const user = userEvent.setup()
+		const inactiveSnapshot = createOnionMoveSnapshot(null, 4)
+		const activeSnapshot = createDefenderMoveSnapshotWithZeroMa()
+		const liveEventSource = createLiveEventSourceStub()
+		const getState = vi
+			.fn()
+			.mockResolvedValueOnce({ snapshot: inactiveSnapshot, session: { role: 'defender' as const } })
+			.mockResolvedValueOnce({ snapshot: activeSnapshot, session: { role: 'defender' as const } })
+			.mockResolvedValue({ snapshot: inactiveSnapshot, session: { role: 'defender' as const } })
+		const pollEvents = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('network down'))
+			.mockResolvedValue([])
+		const client = createGameClient({
+			getState,
+			submitAction: vi.fn().mockResolvedValue(activeSnapshot),
+			pollEvents,
+		})
+
+		render(<App gameClient={client} gameId={123} liveEventSource={liveEventSource as LiveEventSource} />)
+
+		expect(await screen.findByTestId('inactive-event-stream')).not.toBeNull()
+		expect(screen.getByRole('alert')).not.toBeNull()
+		expect(screen.getByText(/unable to refresh inactive events/i)).not.toBeNull()
+
+		await user.click(screen.getByRole('button', { name: /refresh/i }))
+
+		await waitFor(() => {
+			expect(screen.queryByTestId('inactive-event-stream')).toBeNull()
+			expect(screen.queryByRole('alert')).toBeNull()
+		})
+
+		await user.click(screen.getByRole('button', { name: /refresh/i }))
+
+		expect(await screen.findByTestId('inactive-event-stream')).not.toBeNull()
+		expect(screen.queryByRole('alert')).toBeNull()
+		expect(pollEvents).toHaveBeenCalledWith(123, 0)
+		expect(pollEvents).toHaveBeenCalledTimes(2)
+	})
+
 	it('renders structured inactive-event summaries when summary text is absent', async () => {
+		const user = userEvent.setup()
 		const snapshot = createOnionMoveSnapshot(null, 4)
 		const liveEventSource = createLiveEventSourceStub()
 		const pollEvents = vi.fn().mockResolvedValue([
@@ -719,16 +761,21 @@ describe('App UI', () => {
 		const stream = screen.getByTestId('inactive-event-stream')
 		expect(stream.querySelectorAll('.inactive-event-stream-entry').length).toBe(2)
 		const entries = Array.from(stream.querySelectorAll('.inactive-event-stream-entry'))
-		expect(entries[0].getAttribute('title')).toContain('wolf-2 moved to (3, 4)')
-		expect(entries[0].getAttribute('title')).toContain('Rammed units: pigs-1')
-		expect(entries[0].getAttribute('title')).toContain('Tread loss: 1')
-		expect(entries[1].getAttribute('title')).toContain('Attackers: wolf-2')
-		expect(entries[1].getAttribute('title')).toContain('Outcome: X')
-		expect(entries[1].getAttribute('title')).toContain('Treads lost: 2')
-		expect(entries[1].getAttribute('title')).toContain('Unit pigs-1: operational → destroyed')
+		expect(entries[0].querySelector('details')).not.toBeNull()
+		expect(entries[1].querySelector('details')).not.toBeNull()
+		await user.click(entries[0].querySelector('summary') as HTMLElement)
+		expect(entries[0].textContent).toContain('wolf-2 moved to (3, 4)')
+		expect(entries[0].textContent).toContain('Rammed units: pigs-1')
+		expect(entries[0].textContent).toContain('Tread loss: 1')
+		await user.click(entries[1].querySelector('summary') as HTMLElement)
+		expect(entries[1].textContent).toContain('Attackers: wolf-2')
+		expect(entries[1].textContent).toContain('Outcome: X')
+		expect(entries[1].textContent).toContain('Treads lost: 2')
+		expect(entries[1].textContent).toContain('Unit pigs-1: operational → destroyed')
 	})
 
 	it('groups related inactive events by causeId across interleaved noise', async () => {
+		const user = userEvent.setup()
 		const snapshot = createOnionMoveSnapshot(null, 4)
 		const liveEventSource = createLiveEventSourceStub()
 		const pollEvents = vi.fn().mockResolvedValue([
@@ -778,8 +825,11 @@ describe('App UI', () => {
 		expect(await screen.findByText(/ram attempt by wolf-2/i)).not.toBeNull()
 		const stream = screen.getByTestId('inactive-event-stream')
 		expect(stream.querySelectorAll('.inactive-event-stream-entry').length).toBe(1)
-		expect(stream.querySelector('.inactive-event-stream-entry')?.getAttribute('title')).toContain('Rammed units: pigs-1')
-		expect(stream.querySelector('.inactive-event-stream-entry')?.getAttribute('title')).toContain('Treads lost: 1')
+		const entry = stream.querySelector('.inactive-event-stream-entry')
+		expect(entry?.querySelector('details')).not.toBeNull()
+		await user.click(entry?.querySelector('summary') as HTMLElement)
+		expect(entry?.textContent).toContain('Rammed units: pigs-1')
+		expect(entry?.textContent).toContain('Treads lost: 1')
 	})
 
 	it('preserves debug popup position and size when toggled closed and reopened', async () => {

--- a/test/web/app/ui/App.ui.test.tsx
+++ b/test/web/app/ui/App.ui.test.tsx
@@ -728,6 +728,60 @@ describe('App UI', () => {
 		expect(entries[1].getAttribute('title')).toContain('Unit pigs-1: operational → destroyed')
 	})
 
+	it('groups related inactive events by causeId across interleaved noise', async () => {
+		const snapshot = createOnionMoveSnapshot(null, 4)
+		const liveEventSource = createLiveEventSourceStub()
+		const pollEvents = vi.fn().mockResolvedValue([
+			{
+				seq: 61,
+				type: 'UNIT_MOVED',
+				timestamp: '2026-04-15T12:03:00.000Z',
+				unitId: 'wolf-2',
+				to: { q: 3, r: 4 },
+				causeId: 'req-1',
+			},
+			{
+				seq: 62,
+				type: 'PHASE_CHANGED',
+				timestamp: '2026-04-15T12:03:00.500Z',
+				from: 'ONION_MOVE',
+				to: 'DEFENDER_COMBAT',
+				causeId: 'req-1',
+			},
+			{
+				seq: 63,
+				type: 'MOVE_RESOLVED',
+				timestamp: '2026-04-15T12:03:01.000Z',
+				unitId: 'wolf-2',
+				rammedUnitIds: ['pigs-1'],
+				destroyedUnitIds: ['pigs-1'],
+				treadDamage: 1,
+				causeId: 'req-1',
+			},
+			{
+				seq: 64,
+				type: 'ONION_TREADS_LOST',
+				timestamp: '2026-04-15T12:03:01.500Z',
+				amount: 1,
+				remaining: 44,
+				causeId: 'req-1',
+			},
+		])
+		const client = createGameClient({
+			getState: vi.fn().mockResolvedValue({ snapshot, session: { role: 'defender' as const } }),
+			submitAction: vi.fn().mockResolvedValue(snapshot),
+			pollEvents,
+		})
+
+		render(<App gameClient={client} gameId={123} liveEventSource={liveEventSource as LiveEventSource} />)
+
+		expect(await screen.findByText(/ram attempt by wolf-2/i)).not.toBeNull()
+		const stream = screen.getByTestId('inactive-event-stream')
+		expect(stream.querySelectorAll('.inactive-event-stream-entry').length).toBe(1)
+		expect(stream.querySelector('.inactive-event-stream-entry')?.getAttribute('title')).toContain('Rammed units: pigs-1')
+		expect(stream.querySelector('.inactive-event-stream-entry')?.getAttribute('title')).toContain('Treads lost: 1')
+	})
+
 	it('preserves debug popup position and size when toggled closed and reopened', async () => {
 		const user = userEvent.setup()
 		render(<App />)

--- a/test/web/build.test.ts
+++ b/test/web/build.test.ts
@@ -1,10 +1,17 @@
+/// <reference types="node" />
+
 import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
 
 describe('build regression gate', () => {
-	it('passes pnpm run build', { timeout: 15000 }, () => {
+	it('passes the build steps', { timeout: 15000 }, () => {
 		expect(() => {
-			execFileSync('pnpm', ['run', 'build'], {
+			execFileSync(process.execPath, [fileURLToPath(new URL('../../node_modules/typescript/bin/tsc', import.meta.url))], {
+				cwd: process.cwd(),
+				stdio: 'pipe',
+			})
+			execFileSync(process.execPath, [fileURLToPath(new URL('../../scripts/write-dist-package-json.mjs', import.meta.url))], {
 				cwd: process.cwd(),
 				stdio: 'pipe',
 			})

--- a/web/App.css
+++ b/web/App.css
@@ -425,6 +425,41 @@
   gap: 16px;
 }
 
+.inactive-event-stream-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: 14px;
+  padding: 10px 12px;
+}
+
+.inactive-event-stream-notice-error {
+  border: 1px solid rgba(196, 61, 44, 0.24);
+  background: rgba(253, 238, 238, 0.92);
+}
+
+.inactive-event-stream-notice-loading {
+  border: 1px solid rgba(191, 174, 122, 0.28);
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.inactive-event-stream-notice .summary-line {
+  white-space: normal;
+}
+
+.inactive-event-stream-notice-dismiss {
+  flex: none;
+  border: 1px solid rgba(196, 61, 44, 0.28);
+  border-radius: 999px;
+  background: rgba(255, 251, 242, 0.92);
+  color: #7d2f24;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
 .inactive-event-stream-head h3 {
   margin: 0;
   font-size: 0.86rem;

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -428,6 +428,7 @@ function App({ gameClient, gameId, liveEventSource, runtimeConfig, showConnectio
           activeRole={activeRole}
           activeSelectedUnitCount={activeSelectedUnitIds.length}
           isCombatPhase={isCombatPhase}
+          showInactiveEventStream={!sessionTurnActive}
           selectedCombatAttackCount={selectedCombatAttackCount}
           selectedCombatAttackStrength={selectedCombatAttackStrength}
           selectedCombatTarget={selectedCombatTarget}

--- a/web/components/BattlefieldRightRail.tsx
+++ b/web/components/BattlefieldRightRail.tsx
@@ -11,6 +11,7 @@ type BattlefieldRightRailProps = {
   activeRole: 'onion' | 'defender' | null
   activeSelectedUnitCount: number
   isCombatPhase: boolean
+  showInactiveEventStream: boolean
   selectedCombatAttackCount: number
   selectedCombatAttackStrength: number
   selectedCombatTarget: CombatTargetOption | null
@@ -19,8 +20,11 @@ type BattlefieldRightRailProps = {
   selectedInspectorOnion: BattlefieldOnionView | null
   inactiveEventStream: {
     entries: ReadonlyArray<TimelineEvent>
+    errorMessage: string | null
     clearEntries: () => void
+    isLoading: boolean
     isDismissed: boolean
+    clearErrorMessage: () => void
   }
   combatTargetOptions: ReadonlyArray<CombatTargetOption>
   onConfirmCombat: () => void
@@ -32,6 +36,7 @@ export function BattlefieldRightRail({
   activeRole,
   activeSelectedUnitCount,
   isCombatPhase,
+  showInactiveEventStream,
   selectedCombatAttackCount,
   selectedCombatAttackStrength,
   selectedCombatTarget,
@@ -45,10 +50,13 @@ export function BattlefieldRightRail({
 }: BattlefieldRightRailProps) {
   return (
     <aside className="panel rail rail-right">
-      {!inactiveEventStream.isDismissed ? (
+      {showInactiveEventStream && !inactiveEventStream.isDismissed ? (
         <InactiveEventStream
           entries={inactiveEventStream.entries}
+          errorMessage={inactiveEventStream.errorMessage}
+          isLoading={inactiveEventStream.isLoading}
           onDismiss={inactiveEventStream.clearEntries}
+          onDismissError={inactiveEventStream.clearErrorMessage}
         />
       ) : null}
       {selectedInspectorOnion !== null ? (

--- a/web/components/InactiveEventStream.tsx
+++ b/web/components/InactiveEventStream.tsx
@@ -2,10 +2,16 @@ import type { TimelineEvent } from '../lib/battlefieldView'
 
 type InactiveEventStreamProps = {
 	entries: ReadonlyArray<TimelineEvent>
+	errorMessage: string | null
+	isLoading: boolean
 	onDismiss: () => void
+	onDismissError: () => void
 }
 
-export function InactiveEventStream({ entries, onDismiss }: InactiveEventStreamProps) {
+export function InactiveEventStream({ entries, errorMessage, isLoading, onDismiss, onDismissError }: InactiveEventStreamProps) {
+	const showLoading = isLoading && entries.length === 0
+	const showError = errorMessage !== null
+
 	return (
 		<section className="panel panel-subtle inactive-event-stream" role="status" aria-live="polite" data-testid="inactive-event-stream">
 			<div className="inactive-event-stream-head">
@@ -20,13 +26,37 @@ export function InactiveEventStream({ entries, onDismiss }: InactiveEventStreamP
 				</button>
 			</div>
 
+			{showError ? (
+				<div className="inactive-event-stream-notice inactive-event-stream-notice-error" role="alert">
+					<p className="summary-line">{errorMessage}</p>
+					<button className="inactive-event-stream-notice-dismiss" type="button" onClick={onDismissError}>
+						Dismiss notice
+					</button>
+				</div>
+			) : null}
+
+			{showLoading ? (
+				<div className="inactive-event-stream-notice inactive-event-stream-notice-loading" aria-label="Loading inactive events">
+					<span className="event-dot-spinner" aria-hidden="true" />
+					<p className="summary-line">Refreshing remote results.</p>
+				</div>
+			) : null}
+
 			<ul className="inactive-event-stream-list">
 				{entries.length > 0 ? (
 					entries.map((entry) => (
-						<li key={entry.seq} className={`inactive-event-stream-entry tone-${entry.tone ?? 'normal'}`}>
+						<li
+							key={entry.seq}
+							className={`inactive-event-stream-entry tone-${entry.tone ?? 'normal'}`}
+							title={entry.details !== undefined && entry.details.length > 0 ? entry.details.join('\n') : undefined}
+						>
 							<p className="summary-line">{entry.summary}</p>
 						</li>
 					))
+				) : showLoading ? (
+					<li className="inactive-event-stream-entry tone-normal">
+						<p className="summary-line">Loading remote actions.</p>
+					</li>
 				) : (
 					<li className="inactive-event-stream-entry tone-normal">
 						<p className="summary-line">Waiting for remote actions.</p>

--- a/web/components/InactiveEventStream.tsx
+++ b/web/components/InactiveEventStream.tsx
@@ -48,9 +48,20 @@ export function InactiveEventStream({ entries, errorMessage, isLoading, onDismis
 						<li
 							key={entry.seq}
 							className={`inactive-event-stream-entry tone-${entry.tone ?? 'normal'}`}
-							title={entry.details !== undefined && entry.details.length > 0 ? entry.details.join('\n') : undefined}
 						>
 							<p className="summary-line">{entry.summary}</p>
+							{entry.details !== undefined && entry.details.length > 0 ? (
+								<details className="inactive-event-stream-entry-details">
+									<summary className="inactive-event-stream-entry-details-toggle">Details</summary>
+									<ul className="inactive-event-stream-entry-details-list">
+										{entry.details.map((detail, index) => (
+											<li key={`${entry.seq}-${index}`} className="inactive-event-stream-entry-detail">
+												{detail}
+											</li>
+										))}
+									</ul>
+								</details>
+							) : null}
 						</li>
 					))
 				) : showLoading ? (

--- a/web/lib/battlefieldView.ts
+++ b/web/lib/battlefieldView.ts
@@ -59,6 +59,8 @@ export type TimelineEvent = {
   summary: string
   timestamp: string
   tone?: 'normal' | 'alert'
+  details?: ReadonlyArray<string>
+  payload?: Readonly<Record<string, unknown>>
 }
 
 export type TerrainHex = {

--- a/web/lib/gameClient.ts
+++ b/web/lib/gameClient.ts
@@ -1,4 +1,4 @@
-import type { GameState, TurnPhase } from '../../shared/types/index'
+import type { EventEnvelope, GameState, TurnPhase } from '../../shared/types/index'
 import type { GameRequestTransport } from './gameSessionTypes'
 
 export type ScenarioMapSnapshot = {
@@ -64,12 +64,8 @@ export type GameAction =
 	| { type: 'end-phase' }
 	| { type: 'refresh' }
 
-export type GameEvent = {
-	seq: number
-	type: string
+export type GameEvent = EventEnvelope & {
 	summary?: string
-	timestamp: string
-	[key: string]: unknown
 }
 
 export type GameClientError = {

--- a/web/lib/gameClient.ts
+++ b/web/lib/gameClient.ts
@@ -69,6 +69,7 @@ export type GameEvent = {
 	type: string
 	summary?: string
 	timestamp: string
+	[key: string]: unknown
 }
 
 export type GameClientError = {

--- a/web/lib/useInactiveEventStream.ts
+++ b/web/lib/useInactiveEventStream.ts
@@ -117,6 +117,11 @@ function isNoiseEvent(event: InactiveEventPayload): boolean {
 	return isNonEmptyString(event.summary) && /join|connect/i.test(event.summary)
 }
 
+function getEventCauseId(event: InactiveEventPayload): string | null {
+	const causeId = formatRawValue(event.causeId)
+	return causeId.length > 0 ? causeId : null
+}
+
 function buildEventDetails(event: InactiveEventPayload): string[] {
 	switch (event.type) {
 		case 'ONION_MOVED':
@@ -306,6 +311,31 @@ function buildTimelineEvents(events: ReadonlyArray<InactiveEventPayload>): Timel
 
 		if (isNoiseEvent(currentEvent)) {
 			index += 1
+			continue
+		}
+
+		const currentCauseId = getEventCauseId(currentEvent)
+		if (currentCauseId !== null) {
+			const relatedEvents: InactiveEventPayload[] = [currentEvent]
+			let nextIndex = index + 1
+
+			while (nextIndex < events.length) {
+				const nextEvent = events[nextIndex]
+				if (isNoiseEvent(nextEvent)) {
+					nextIndex += 1
+					continue
+				}
+
+				if (getEventCauseId(nextEvent) !== currentCauseId) {
+					break
+				}
+
+				relatedEvents.push(nextEvent)
+				nextIndex += 1
+			}
+
+			timelineEntries.push(buildTimelineEntry(relatedEvents))
+			index = nextIndex
 			continue
 		}
 

--- a/web/lib/useInactiveEventStream.ts
+++ b/web/lib/useInactiveEventStream.ts
@@ -426,6 +426,7 @@ export function useInactiveEventStream({
 			pollEvents === undefined
 		) {
 			setIsLoading(false)
+			setErrorMessage(null)
 			return
 		}
 

--- a/web/lib/useInactiveEventStream.ts
+++ b/web/lib/useInactiveEventStream.ts
@@ -11,23 +11,346 @@ type UseInactiveEventStreamOptions = {
 	pollEvents?: GameRequestTransport['pollEvents']
 }
 
+type InactiveEventPayload = GameEvent & {
+	attackers?: unknown
+	amount?: unknown
+	destroyedUnitIds?: unknown
+	from?: unknown
+	// Keep the payload open so the web client can render structured summaries from backend envelopes.
+	outcome?: unknown
+	odds?: unknown
+	rammedUnitIds?: unknown
+	remaining?: unknown
+	roll?: unknown
+	squadsLost?: unknown
+	targetId?: unknown
+	to?: unknown
+	unitId?: unknown
+	weaponId?: unknown
+	weaponType?: unknown
+	treadDamage?: unknown
+}
 
-function formatEventSummary(event: GameEvent) {
-	if (typeof event.summary === 'string' && event.summary.trim().length > 0) {
+const MOVE_EVENT_TYPES = new Set(['ONION_MOVED', 'UNIT_MOVED'])
+const RESOLVED_EVENT_TYPES = new Set(['FIRE_RESOLVED', 'MOVE_RESOLVED'])
+const FOLLOW_UP_EVENT_TYPES = new Set(['ONION_TREADS_LOST', 'ONION_BATTERY_DESTROYED', 'UNIT_STATUS_CHANGED', 'UNIT_SQUADS_LOST'])
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === 'string' && value.trim().length > 0
+}
+
+function humanizeIdentifier(value: unknown): string {
+	if (!isNonEmptyString(value)) {
+		return ''
+	}
+
+	const normalized = value.replace(/[_-]+/g, ' ').trim().toLowerCase()
+	return normalized.length > 0 ? normalized.charAt(0).toUpperCase() + normalized.slice(1) : ''
+}
+
+function formatRawValue(value: unknown): string {
+	return isNonEmptyString(value) ? value : ''
+}
+
+function formatValueList(value: unknown): string {
+	if (!Array.isArray(value)) {
+		return formatDetailValue(value)
+	}
+
+	return value.map((item) => formatDetailValue(item)).filter((item) => item.length > 0).join(', ')
+}
+
+function formatCoordinate(value: unknown): string {
+	if (value === null || value === undefined || typeof value !== 'object') {
+		return formatDetailValue(value)
+	}
+
+	const candidate = value as { q?: unknown; r?: unknown }
+	if (typeof candidate.q === 'number' && typeof candidate.r === 'number') {
+		return `(${candidate.q}, ${candidate.r})`
+	}
+
+	return formatObjectValue(value as Record<string, unknown>)
+}
+
+function formatObjectValue(value: Record<string, unknown>): string {
+	const entries = Object.entries(value)
+		.filter(([, entryValue]) => entryValue !== undefined)
+		.map(([key, entryValue]) => `${key}: ${formatDetailValue(entryValue)}`)
+
+	return entries.join(', ')
+}
+
+function formatDetailValue(value: unknown): string {
+	if (typeof value === 'string') {
+		return value
+	}
+
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value)
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => formatDetailValue(item)).filter((item) => item.length > 0).join(', ')
+	}
+
+	if (value === null || value === undefined) {
+		return '—'
+	}
+
+	if (typeof value === 'object') {
+		return formatObjectValue(value as Record<string, unknown>)
+	}
+
+	return String(value)
+}
+
+function isNoiseEvent(event: InactiveEventPayload): boolean {
+	if (event.type === 'PHASE_CHANGED') {
+		return true
+	}
+
+	if (/join|connect/i.test(event.type)) {
+		return true
+	}
+
+	return isNonEmptyString(event.summary) && /join|connect/i.test(event.summary)
+}
+
+function buildEventDetails(event: InactiveEventPayload): string[] {
+	switch (event.type) {
+		case 'ONION_MOVED':
+			return [`The Onion moved to ${formatCoordinate(event.to)}`]
+		case 'UNIT_MOVED': {
+			const unitId = formatRawValue(event.unitId)
+			const destination = formatCoordinate(event.to)
+			return unitId.length > 0 ? [`${unitId} moved to ${destination}`] : [`Moved to ${destination}`]
+		}
+		case 'FIRE_RESOLVED': {
+			const details: string[] = []
+			if (Array.isArray(event.attackers) && event.attackers.length > 0) {
+				details.push(`Attackers: ${formatValueList(event.attackers)}`)
+			}
+			if (formatRawValue(event.targetId).length > 0) {
+				details.push(`Target: ${formatRawValue(event.targetId)}`)
+			}
+			if (event.roll !== undefined) {
+				details.push(`Roll: ${formatDetailValue(event.roll)}`)
+			}
+			if (event.outcome !== undefined) {
+				details.push(`Outcome: ${formatDetailValue(event.outcome)}`)
+			}
+			if (event.odds !== undefined) {
+				details.push(`Odds: ${formatDetailValue(event.odds)}`)
+			}
+			return details
+		}
+		case 'MOVE_RESOLVED': {
+			const details: string[] = []
+			if (formatRawValue(event.unitId).length > 0) {
+				details.push(`Mover: ${formatRawValue(event.unitId)}`)
+			}
+			if (Array.isArray(event.rammedUnitIds) && event.rammedUnitIds.length > 0) {
+				details.push(`Rammed units: ${formatValueList(event.rammedUnitIds)}`)
+			}
+			if (Array.isArray(event.destroyedUnitIds) && event.destroyedUnitIds.length > 0) {
+				details.push(`Destroyed units: ${formatValueList(event.destroyedUnitIds)}`)
+			}
+			if (typeof event.treadDamage === 'number' && event.treadDamage > 0) {
+				details.push(`Tread loss: ${event.treadDamage}`)
+			}
+			return details
+		}
+		case 'ONION_TREADS_LOST': {
+			const details: string[] = []
+			if (typeof event.amount === 'number') {
+				details.push(`Treads lost: ${event.amount}`)
+			}
+			if (typeof event.remaining === 'number') {
+				details.push(`Remaining: ${event.remaining}`)
+			}
+			return details
+		}
+		case 'ONION_BATTERY_DESTROYED': {
+			const weaponType = humanizeIdentifier(event.weaponType)
+			return [weaponType.length > 0 ? `Battery destroyed: ${weaponType}` : 'Battery destroyed']
+		}
+		case 'UNIT_STATUS_CHANGED': {
+			const unitId = formatRawValue(event.unitId)
+			const from = formatRawValue(event.from)
+			const to = formatRawValue(event.to)
+			return unitId.length > 0 && from.length > 0 && to.length > 0 ? [`Unit ${unitId}: ${from} → ${to}`] : ['Unit status changed']
+		}
+		case 'UNIT_SQUADS_LOST': {
+			const unitId = formatRawValue(event.unitId)
+			const amount = typeof event.amount === 'number' ? String(event.amount) : formatDetailValue(event.amount)
+			return unitId.length > 0 ? [`Squads lost for ${unitId}: ${amount}`] : [`Squads lost: ${amount}`]
+		}
+		default:
+			return []
+	}
+}
+
+function buildPrimarySummary(event: InactiveEventPayload, relatedEvents: ReadonlyArray<InactiveEventPayload>): string {
+	if (event.type === 'FIRE_RESOLVED') {
+		const target = formatRawValue(event.targetId)
+		const fragments: string[] = []
+		if (target.length > 0) {
+			fragments.push(`Fire on ${target}`)
+		} else {
+			fragments.push('Fire resolved')
+		}
+
+		if (event.outcome !== undefined) {
+			fragments.push(`result ${formatDetailValue(event.outcome)}`)
+		}
+
+		return fragments.join(': ')
+	}
+
+	if (event.type === 'MOVE_RESOLVED' || MOVE_EVENT_TYPES.has(event.type)) {
+		const mover = formatRawValue(event.unitId)
+		const moveDetails = relatedEvents.flatMap((relatedEvent) => buildEventDetails(relatedEvent))
+		const ramDetails = moveDetails.filter((detail) => /rammed|destroyed|tread loss/i.test(detail))
+		if (ramDetails.length > 0) {
+			return mover.length > 0 ? `Ram attempt by ${mover}` : 'Ram attempt resolved'
+		}
+
+		if (mover.length > 0) {
+			return `Move by ${mover}`
+		}
+
+		return 'Move resolved'
+	}
+
+	return formatEventSummary(event)
+}
+
+function formatEventSummary(event: InactiveEventPayload) {
+	if (isNonEmptyString(event.summary)) {
 		return event.summary
 	}
 
-	return event.type.replace(/_/g, ' ').toLowerCase()
+	switch (event.type) {
+		case 'UNIT_STATUS_CHANGED': {
+			const unitId = formatRawValue(event.unitId)
+			const from = formatRawValue(event.from)
+			const to = formatRawValue(event.to)
+			return unitId.length > 0 && from.length > 0 && to.length > 0 ? `Unit ${unitId}: ${from} → ${to}` : 'Unit status changed'
+		}
+		case 'MOVE_RESOLVED': {
+			const unitId = formatRawValue(event.unitId)
+			const fragments: string[] = []
+			if (unitId.length > 0) {
+				fragments.push(`Move resolved for ${unitId}`)
+			} else {
+				fragments.push('Move resolved')
+			}
+
+			if (Array.isArray(event.rammedUnitIds) && event.rammedUnitIds.length > 0) {
+				fragments.push(`${event.rammedUnitIds.length} rammed`)
+			}
+
+			if (Array.isArray(event.destroyedUnitIds) && event.destroyedUnitIds.length > 0) {
+				fragments.push(`${event.destroyedUnitIds.length} destroyed`)
+			}
+
+			if (typeof event.treadDamage === 'number' && event.treadDamage > 0) {
+				fragments.push(`${event.treadDamage} tread loss`)
+			}
+
+			return fragments.join(', ')
+		}
+		case 'FIRE_RESOLVED': {
+			const targetId = formatRawValue(event.targetId)
+			return targetId.length > 0 ? `Fire resolved on target ${targetId}` : 'Fire resolved'
+		}
+		case 'ONION_TREADS_LOST': {
+			return typeof event.amount === 'number' ? `The Onion lost ${event.amount} treads` : 'The Onion lost treads'
+		}
+		case 'ONION_BATTERY_DESTROYED': {
+			const weaponType = humanizeIdentifier(event.weaponType)
+			return weaponType.length > 0 ? `The Onion lost the ${weaponType} battery` : 'The Onion lost a battery'
+		}
+		default:
+			return event.type.replace(/_/g, ' ').toLowerCase()
+	}
 }
 
-function toTimelineEvent(event: GameEvent): TimelineEvent {
+function buildTimelineEntry(events: ReadonlyArray<InactiveEventPayload>): TimelineEvent {
+	const primaryEvent = events.find((event) => RESOLVED_EVENT_TYPES.has(event.type) || MOVE_EVENT_TYPES.has(event.type)) ?? events[0]
+	const details = events.flatMap((event) => buildEventDetails(event))
+	const summary = isNonEmptyString(primaryEvent.summary) ? primaryEvent.summary : buildPrimarySummary(primaryEvent, events)
+
 	return {
-		seq: event.seq,
-		type: event.type,
-		summary: formatEventSummary(event),
-		timestamp: event.timestamp,
-		tone: event.type === 'UNIT_STATUS_CHANGED' || event.type === 'PHASE_CHANGED' ? 'alert' : 'normal',
+		seq: primaryEvent.seq,
+		type: primaryEvent.type,
+		summary,
+		timestamp: primaryEvent.timestamp,
+		tone: primaryEvent.type === 'UNIT_STATUS_CHANGED' ? 'alert' : 'normal',
+		details,
+		payload: primaryEvent,
 	}
+}
+
+function shouldAttachToPreviousGroup(eventType: string): boolean {
+	return FOLLOW_UP_EVENT_TYPES.has(eventType)
+}
+
+function buildTimelineEvents(events: ReadonlyArray<InactiveEventPayload>): TimelineEvent[] {
+	const timelineEntries: TimelineEvent[] = []
+	let index = 0
+
+	while (index < events.length) {
+		const currentEvent = events[index]
+
+		if (isNoiseEvent(currentEvent)) {
+			index += 1
+			continue
+		}
+
+		if (MOVE_EVENT_TYPES.has(currentEvent.type)) {
+			const relatedEvents: InactiveEventPayload[] = [currentEvent]
+			let nextIndex = index + 1
+
+			if (nextIndex < events.length && events[nextIndex].type === 'MOVE_RESOLVED') {
+				relatedEvents.push(events[nextIndex] as InactiveEventPayload)
+				nextIndex += 1
+			}
+
+			while (nextIndex < events.length && shouldAttachToPreviousGroup(events[nextIndex].type)) {
+				relatedEvents.push(events[nextIndex] as InactiveEventPayload)
+				nextIndex += 1
+			}
+
+			timelineEntries.push(buildTimelineEntry(relatedEvents))
+			index = nextIndex
+			continue
+		}
+
+		if (RESOLVED_EVENT_TYPES.has(currentEvent.type)) {
+			const relatedEvents: InactiveEventPayload[] = [currentEvent]
+			let nextIndex = index + 1
+
+			while (nextIndex < events.length && shouldAttachToPreviousGroup(events[nextIndex].type)) {
+				relatedEvents.push(events[nextIndex] as InactiveEventPayload)
+				nextIndex += 1
+			}
+
+			timelineEntries.push(buildTimelineEntry(relatedEvents))
+			index = nextIndex
+			continue
+		}
+
+		timelineEntries.push(buildTimelineEntry([currentEvent]))
+		index += 1
+	}
+
+	return timelineEntries
+}
+
+function toTimelineEvents(events: ReadonlyArray<GameEvent>): TimelineEvent[] {
+	return buildTimelineEvents(events as ReadonlyArray<InactiveEventPayload>)
 }
 
 export function useInactiveEventStream({
@@ -38,6 +361,8 @@ export function useInactiveEventStream({
 }: UseInactiveEventStreamOptions) {
 	const [entries, setEntries] = useState<TimelineEvent[]>([])
 	const [isDismissed, setIsDismissed] = useState(false)
+	const [isLoading, setIsLoading] = useState(false)
+	const [errorMessage, setErrorMessage] = useState<string | null>(null)
 	const seenSeqsRef = useRef(new Set<number>())
 	const loadedThroughSeqRef = useRef<number | null>(null)
 	const inFlightAfterSeqRef = useRef<number | null>(null)
@@ -54,6 +379,8 @@ export function useInactiveEventStream({
 			lastGameIdRef.current = activeGameId
 			setEntries([])
 			setIsDismissed(false)
+			setIsLoading(false)
+			setErrorMessage(null)
 			seenSeqsRef.current = new Set<number>()
 			loadedThroughSeqRef.current = null
 			inFlightAfterSeqRef.current = null
@@ -68,6 +395,7 @@ export function useInactiveEventStream({
 			activeGameId === null ||
 			pollEvents === undefined
 		) {
+			setIsLoading(false)
 			return
 		}
 
@@ -88,8 +416,11 @@ export function useInactiveEventStream({
 		async function loadEvents() {
 			// Guard pollEvents and arguments
 			if (pollEvents === undefined || activeGameId === null) {
+				setIsLoading(false)
 				return undefined
 			}
+			setIsLoading(true)
+			setErrorMessage(null)
 			try {
 				const events = await pollEvents(Number(activeGameId), Number(afterSeq))
 				if (cancelled) {
@@ -103,7 +434,7 @@ export function useInactiveEventStream({
 
 				if (unseenEvents.length > 0) {
 					setEntries((currentEntries) => {
-						const nextEntries = currentEntries.concat(unseenEvents.map(toTimelineEvent))
+						const nextEntries = currentEntries.concat(toTimelineEvents(unseenEvents))
 						nextEntries.sort((left, right) => left.seq - right.seq)
 						return nextEntries
 					})
@@ -114,8 +445,11 @@ export function useInactiveEventStream({
 				// Default lastAppliedEventSeq to 0 if null
 				loadedThroughSeqRef.current = Math.max(maxReturnedSeq, lastAppliedEventSeq ?? 0)
 			} catch {
-				// Keep the existing stream in place; the next live hint can retry.
+				if (!cancelled) {
+					setErrorMessage('Unable to refresh inactive events.')
+				}
 			} finally {
+				let shouldReload = false
 				if (inFlightAfterSeqRef.current === afterSeq) {
 					inFlightAfterSeqRef.current = null
 				}
@@ -127,8 +461,14 @@ export function useInactiveEventStream({
 					loadedThroughSeqRef.current !== null &&
 					loadedThroughSeqRef.current < latestAppliedEventSeqRef.current
 				) {
+					shouldReload = true
 					queuedRefreshRef.current = false
+				}
+
+				if (shouldReload) {
 					void loadEvents()
+				} else {
+					setIsLoading(false)
 				}
 
 				queuedRefreshRef.current = false
@@ -148,11 +488,20 @@ export function useInactiveEventStream({
 	function clearEntries() {
 		setEntries([])
 		setIsDismissed(true)
+		setIsLoading(false)
+		setErrorMessage(null)
+	}
+
+	function clearErrorMessage() {
+		setErrorMessage(null)
 	}
 
 	return {
 		clearEntries,
 		entries,
+		errorMessage,
+		isLoading,
 		isDismissed,
+		clearErrorMessage,
 	}
 }


### PR DESCRIPTION
This PR introduces an inactive event stream for the web UI so game events remain visible when the session is idle.

Highlights:
- Adds a new `InactiveEventStream` component and `useInactiveEventStream` hook to group and render events
- Updates battlefield layout and app styling to make room for the new stream
- Expands UI and server test coverage to validate the new behavior